### PR TITLE
fix(security): make JWT_SECRET mandatory (fail closed)

### DIFF
--- a/packages/server/src/__tests__/config-edge-cases.test.ts
+++ b/packages/server/src/__tests__/config-edge-cases.test.ts
@@ -8,7 +8,11 @@ import {
   resetConfig,
   setConfig,
   ConfigSchema,
+  resolveJwtSecret,
+  DEV_JWT_SECRET_PLACEHOLDER,
 } from "../config.js";
+
+const REAL_SECRET = "a-real-jwt-secret-that-is-at-least-32-chars!!";
 
 describe("config edge cases", () => {
   const originalEnv = process.env;
@@ -318,6 +322,32 @@ describe("config edge cases", () => {
       resetConfig();
       process.env.PORT = "5000";
       expect(getConfig().port).toBe(5000);
+    });
+  });
+
+  describe("resolveJwtSecret (fail-closed)", () => {
+    for (const authMode of ["dual", "oidc-required"] as const) {
+      it(`throws when JWT_SECRET is unset in ${authMode} mode`, () => {
+        const config = parseConfig({ authMode });
+        expect(() => resolveJwtSecret(config)).toThrow(/JWT_SECRET is required/);
+      });
+
+      it(`throws when JWT_SECRET equals the dev placeholder in ${authMode} mode`, () => {
+        // The placeholder is <32 chars, so inject it past schema validation.
+        const config = { ...parseConfig({ authMode }), jwtSecret: DEV_JWT_SECRET_PLACEHOLDER };
+        expect(() => resolveJwtSecret(config)).toThrow(/JWT_SECRET is required/);
+      });
+
+      it(`returns the real secret in ${authMode} mode when set`, () => {
+        const config = parseConfig({ authMode, jwtSecret: REAL_SECRET });
+        expect(resolveJwtSecret(config)).toBe(REAL_SECRET);
+      });
+    }
+
+    it("does not throw in api-key-only mode when JWT_SECRET is unset (JWT unused)", () => {
+      const config = parseConfig({ authMode: "api-key-only" });
+      expect(() => resolveJwtSecret(config)).not.toThrow();
+      expect(resolveJwtSecret(config)).toBe(DEV_JWT_SECRET_PLACEHOLDER);
     });
   });
 

--- a/packages/server/src/__tests__/global-setup.ts
+++ b/packages/server/src/__tests__/global-setup.ts
@@ -1,0 +1,13 @@
+/**
+ * Vitest global setup (runs before any test module is imported).
+ *
+ * Provides a real, test-only JWT_SECRET so that importing the server app
+ * (src/index.ts) does not fail closed. The app now refuses to start when
+ * JWT/OIDC auth is enabled (the default "dual" AUTH_MODE) without a real
+ * JWT_SECRET — see resolveJwtSecret() in src/config.ts. This is a real
+ * secret for tests, NOT the production dev-placeholder fallback that was
+ * removed for security.
+ */
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = "test-only-jwt-secret-at-least-32-characters-long!!";
+}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -440,6 +440,47 @@ export function validateProductionConfig(config: Config): string[] {
 }
 
 // ============================================================================
+// JWT Secret Resolution (fail-closed)
+// ============================================================================
+
+/** The dev placeholder that must never be used as a real signing secret. */
+export const DEV_JWT_SECRET_PLACEHOLDER = "dev-secret-not-for-production";
+
+/**
+ * Resolve the JWT signing/verification secret, failing closed.
+ *
+ * JWT is only used when auth mode is "dual" or "oidc-required". In
+ * "api-key-only" mode JWT auth is never exercised, so a secret is not
+ * required and this returns the (unused) placeholder to keep that
+ * fully-supported mode working.
+ *
+ * In any JWT-enabled mode, if JWT_SECRET is unset or equals the dev
+ * placeholder, this THROWS — we refuse to sign/verify tokens with a
+ * known secret rather than silently weakening auth.
+ *
+ * @throws {Error} when JWT is enabled but no real secret is configured
+ */
+export function resolveJwtSecret(config: Config): string {
+  const jwtEnabled = config.authMode !== "api-key-only";
+
+  if (!jwtEnabled) {
+    // JWT is not used in api-key-only mode; secret value is irrelevant.
+    return config.jwtSecret ?? DEV_JWT_SECRET_PLACEHOLDER;
+  }
+
+  if (!config.jwtSecret || config.jwtSecret === DEV_JWT_SECRET_PLACEHOLDER) {
+    throw new Error(
+      `JWT_SECRET is required when AUTH_MODE is "${config.authMode}" ` +
+        `(JWT/OIDC auth is enabled). Set JWT_SECRET to a strong secret of ` +
+        `at least 32 characters. Refusing to start with a known/placeholder ` +
+        `signing secret.`
+    );
+  }
+
+  return config.jwtSecret;
+}
+
+// ============================================================================
 // Singleton Config Instance
 // ============================================================================
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,7 +24,7 @@ import probesRouter from "./routes/probes.js";
 import { registry, httpRequestsTotal, httpRequestDuration } from "./lib/metrics.js";
 import { authMiddleware, type AuthVariables } from "./middleware/auth.js";
 import authRouter from "./routes/auth.js";
-import { getConfig, validateProductionConfig } from "./config.js";
+import { getConfig, validateProductionConfig, resolveJwtSecret } from "./config.js";
 import { securityHeadersMiddleware } from "./middleware/security-headers.js";
 import { initDatabase, runMigrations, closeDatabase, getDb, approvalRequests } from "./db/index.js";
 import { getRateLimiter, resetRateLimiter } from "./lib/rate-limiter/index.js";
@@ -54,6 +54,17 @@ if (config.isProduction) {
   }
   // Log non-critical warnings
   warnings.filter(w => !w.includes('ADMIN_API_KEY')).forEach(w => log.warn(w));
+}
+
+// Fail closed at startup (every env): if JWT/OIDC auth is enabled, a real
+// JWT_SECRET is mandatory. resolveJwtSecret throws when it is unset or equals
+// the dev placeholder — refuse to start rather than sign/verify with a known
+// secret. (api-key-only mode never uses JWT, so this is a no-op there.)
+try {
+  resolveJwtSecret(config);
+} catch (err) {
+  log.fatal((err as Error).message);
+  process.exit(1);
 }
 
 // Request correlation ID middleware

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -7,7 +7,7 @@ import type { Context, Next } from "hono";
 import { eq } from "drizzle-orm";
 import { getDb, users, type ApiKey } from "../db/index.js";
 import { getRateLimiter, type RateLimitResult } from "../lib/rate-limiter/index.js";
-import { getConfig } from "../config.js";
+import { getConfig, resolveJwtSecret } from "../config.js";
 import { validateApiKey } from "../lib/api-keys.js";
 import {
   verifyAccessToken,
@@ -56,7 +56,7 @@ function getAuthConfig(): AuthConfig {
         }
       : null,
     jwt: {
-      secret: config.jwtSecret || 'dev-secret-not-for-production',
+      secret: resolveJwtSecret(config),
       accessTokenTtlSeconds: config.jwtAccessTtl,
       refreshTokenTtlSeconds: config.jwtRefreshTtl,
     },

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -11,7 +11,7 @@ import { Hono } from "hono";
 import { nanoid } from "nanoid";
 import { eq } from "drizzle-orm";
 import { getDb, users, refreshTokens } from "../db/index.js";
-import { getConfig } from "../config.js";
+import { getConfig, resolveJwtSecret } from "../config.js";
 import {
   OidcClient,
   signAccessToken,
@@ -54,7 +54,7 @@ function getAuthConfig(): AuthConfig {
         }
       : null,
     jwt: {
-      secret: config.jwtSecret || 'dev-secret-not-for-production',
+      secret: resolveJwtSecret(config),
       accessTokenTtlSeconds: config.jwtAccessTtl,
       refreshTokenTtlSeconds: config.jwtRefreshTtl,
     },

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    // Sets a real test-only JWT_SECRET before any module is imported so the
+    // server app (which now fails closed without one) can load in tests.
+    setupFiles: ['./src/__tests__/global-setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Removes the `dev-secret-not-for-production` JWT fallback that silently weakened auth in non-local deploys.

- New `resolveJwtSecret(config)` **throws** when JWT/OIDC auth is enabled and `JWT_SECRET` is unset or is the dev placeholder; **no-op** in api-key-only mode.
- The verify + sign paths use it; `index.ts` gates startup on it (`process.exit(1)` with a clear message) — **fail closed** rather than disabling JWT (which would itself be a downgrade).
- Tests set a real test-only secret via a vitest global-setup; +7 unit tests for the new logic.

Verified: `pnpm -r build` clean; 595 server tests pass (the 1 failure is a pre-existing, unrelated Redis-timing test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)