### PR TITLE
feat(server): reactive guardrails — fold in agentkit-guardrails

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -91,6 +91,17 @@ DATABASE_URL=postgresql://user:pass@db.example.com:5432/agentgate?sslmode=requir
 | `RATE_LIMIT_ENABLED` | boolean | `true` | Enable rate limiting |
 | `RATE_LIMIT_RPM` | number | `60` | Requests per minute per API key |
 
+### Reactive Guardrails
+
+AgentGate can react to AgentLens metric alerts: when a monitored metric is breached,
+it creates a policy override (require approval for matching tools) and removes it on
+recovery. AgentLens posts to `POST /api/guardrails/webhook` with a shared secret.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `GUARDRAILS_WEBHOOK_SECRET` | string | - | Shared secret for the AgentLens webhook (sent as `x-guardrails-secret`). **Unset = fail closed** (every webhook is rejected). |
+| `GUARDRAILS_RULES` | JSON | `[]` | Array of rules: `{ "metric": "error_rate", "toolPattern": "*", "ttlSeconds": 3600, "reason": "…" }`. On `breach` of `metric`, tools matching `toolPattern` require approval until `recovery` (or `ttlSeconds` elapses). |
+
 ### Request Handling
 
 | Variable | Type | Default | Description |

--- a/packages/server/src/__tests__/guardrails.test.ts
+++ b/packages/server/src/__tests__/guardrails.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb, type TestContext } from "./setup.js";
+import { overrides } from "../db/schema.js";
+import {
+  applyBreach,
+  applyRecovery,
+  matchRule,
+  loadRulesFromEnv,
+  OverrideTracker,
+  type GuardrailRule,
+} from "../routes/guardrails.js";
+
+let ctx: TestContext;
+
+beforeEach(() => {
+  ctx = createTestDb();
+});
+
+afterEach(() => {
+  ctx.cleanup();
+});
+
+const RULES: GuardrailRule[] = [
+  { metric: "error_rate", toolPattern: "*", ttlSeconds: 3600, reason: "Error rate high" },
+  { metric: "latency_p99", toolPattern: "external_api.*", ttlSeconds: 1800 },
+];
+
+describe("reactive guardrails", () => {
+  it("matchRule selects the rule for a metric", () => {
+    expect(matchRule("error_rate", RULES)?.toolPattern).toBe("*");
+    expect(matchRule("latency_p99", RULES)?.toolPattern).toBe("external_api.*");
+    expect(matchRule("unknown_metric", RULES)).toBeUndefined();
+  });
+
+  it("loadRulesFromEnv parses a JSON array and tolerates junk", () => {
+    process.env.GUARDRAILS_RULES = JSON.stringify(RULES);
+    expect(loadRulesFromEnv()).toHaveLength(2);
+    process.env.GUARDRAILS_RULES = "not json";
+    expect(loadRulesFromEnv()).toEqual([]);
+    delete process.env.GUARDRAILS_RULES;
+    expect(loadRulesFromEnv()).toEqual([]);
+  });
+
+  it("breach creates a require_approval override; recovery removes it", async () => {
+    const tracker = new OverrideTracker();
+
+    const id = await applyBreach(ctx.db, RULES[0]!, "agent-1", tracker);
+    let rows = await ctx.db.select().from(overrides).where(eq(overrides.id, id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.action).toBe("require_approval");
+    expect(rows[0]!.agentId).toBe("agent-1");
+    expect(rows[0]!.toolPattern).toBe("*");
+    expect(rows[0]!.reason).toBe("Error rate high");
+    expect(rows[0]!.expiresAt).not.toBeNull();
+
+    const removed = await applyRecovery(ctx.db, "agent-1", "error_rate", tracker);
+    expect(removed).toBe(id);
+    rows = await ctx.db.select().from(overrides).where(eq(overrides.id, id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("defaults the reason when a rule omits it", async () => {
+    const tracker = new OverrideTracker();
+    const id = await applyBreach(ctx.db, RULES[1]!, "agent-2", tracker);
+    const rows = await ctx.db.select().from(overrides).where(eq(overrides.id, id));
+    expect(rows[0]!.reason).toContain("latency_p99");
+  });
+
+  it("recovery without a matching breach is a no-op", async () => {
+    const tracker = new OverrideTracker();
+    expect(await applyRecovery(ctx.db, "agent-x", "error_rate", tracker)).toBeNull();
+  });
+
+  it("tracks overrides per (agent, metric) independently", async () => {
+    const tracker = new OverrideTracker();
+    const a = await applyBreach(ctx.db, RULES[0]!, "agent-1", tracker);
+    const b = await applyBreach(ctx.db, RULES[0]!, "agent-2", tracker);
+    expect(a).not.toBe(b);
+    expect(await applyRecovery(ctx.db, "agent-1", "error_rate", tracker)).toBe(a);
+    // agent-2's override survives
+    const rows = await ctx.db.select().from(overrides).where(eq(overrides.id, b));
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,7 @@ import auditRouter from "./routes/audit.js";
 import analyticsRouter from "./routes/analytics.js";
 import tokensRouter from "./routes/tokens.js";
 import decideRouter from "./routes/decide.js";
+import { createGuardrailsRouter } from "./routes/guardrails.js";
 import overridesRouter from "./routes/overrides.js";
 import { startOverrideCleanup, stopOverrideCleanup } from "./routes/overrides.js";
 import channelsRouter from "./routes/channels.js";
@@ -174,6 +175,10 @@ app.get("/health", async (c) => {
 
 // Decision endpoint (public, no auth required - uses tokens)
 app.route("/api/decide", decideRouter);
+
+// Reactive guardrails webhook from AgentLens (public — authenticated by a shared
+// secret inside the router, so it must be mounted before the user-auth middleware).
+app.route("/api/guardrails", createGuardrailsRouter());
 
 // Auth routes (mostly public — login, callback, refresh, logout)
 // /auth/me requires auth and is handled inside the router

--- a/packages/server/src/routes/guardrails.ts
+++ b/packages/server/src/routes/guardrails.ts
@@ -1,0 +1,185 @@
+// @agentgate/server — Reactive guardrails
+//
+// Folds in the former standalone `agentkit-guardrails` service. AgentLens monitors
+// agent metrics (error rate, latency, token usage, …) and POSTs a breach/recovery
+// webhook here. On breach we create a policy override that requires approval for the
+// configured tools; on recovery we remove it. The override also carries a TTL so a
+// missed recovery webhook still expires (AgentGate's override cleanup deletes it).
+//
+// AgentGate's override model is `require_approval`-only, so that is the action.
+// The endpoint is authenticated by a shared secret (fail closed if unset), like a
+// webhook — it is mounted before the user-auth middleware.
+
+import { Hono } from "hono";
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { getDb, overrides } from "../db/index.js";
+
+type Db = ReturnType<typeof getDb>;
+
+export interface GuardrailRule {
+  /** AgentLens metric name, e.g. "error_rate", "latency_p99". */
+  metric: string;
+  /** Glob of tools to gate while the metric is breached (e.g. "*", "external_api.*"). */
+  toolPattern: string;
+  /** Override auto-expires after this many seconds (safety net for a missed recovery). */
+  ttlSeconds?: number;
+  /** Human-readable reason recorded on the override. */
+  reason?: string;
+}
+
+interface WebhookPayload {
+  event: "breach" | "recovery";
+  metric: string;
+  agentId: string;
+}
+
+/** Parse rules from the GUARDRAILS_RULES env var (a JSON array of GuardrailRule). */
+export function loadRulesFromEnv(): GuardrailRule[] {
+  const raw = process.env.GUARDRAILS_RULES;
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as GuardrailRule[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function matchRule(metric: string, rules: GuardrailRule[]): GuardrailRule | undefined {
+  return rules.find((r) => r.metric === metric);
+}
+
+function overrideKey(agentId: string, metric: string): string {
+  return `${agentId}::${metric}`;
+}
+
+/**
+ * Tracks the override id created for each (agent, metric) breach so the matching
+ * recovery webhook can remove it. A per-entry timer drops the in-memory mapping
+ * after the rule's TTL even if no recovery arrives (the DB override expires
+ * independently via the override cleanup loop).
+ */
+export class OverrideTracker {
+  private map = new Map<string, string>();
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  set(key: string, id: string, ttlSeconds?: number): void {
+    this.clearTimer(key);
+    this.map.set(key, id);
+    if (ttlSeconds && ttlSeconds > 0) {
+      const t = setTimeout(() => {
+        this.map.delete(key);
+        this.timers.delete(key);
+      }, ttlSeconds * 1000);
+      if (typeof t === "object" && "unref" in t) t.unref();
+      this.timers.set(key, t);
+    }
+  }
+
+  take(key: string): string | undefined {
+    const id = this.map.get(key);
+    if (id !== undefined) {
+      this.map.delete(key);
+      this.clearTimer(key);
+    }
+    return id;
+  }
+
+  private clearTimer(key: string): void {
+    const t = this.timers.get(key);
+    if (t) {
+      clearTimeout(t);
+      this.timers.delete(key);
+    }
+  }
+}
+
+/** On breach: create a require-approval override for the rule's tools. Returns the override id. */
+export async function applyBreach(
+  db: Db,
+  rule: GuardrailRule,
+  agentId: string,
+  tracker: OverrideTracker,
+): Promise<string> {
+  const id = nanoid();
+  const now = new Date();
+  const expiresAt = rule.ttlSeconds ? new Date(now.getTime() + rule.ttlSeconds * 1000) : null;
+  await db.insert(overrides).values({
+    id,
+    agentId,
+    toolPattern: rule.toolPattern,
+    action: "require_approval",
+    reason: rule.reason ?? `AgentLens metric "${rule.metric}" breached`,
+    createdAt: now,
+    expiresAt,
+  });
+  tracker.set(overrideKey(agentId, rule.metric), id, rule.ttlSeconds);
+  return id;
+}
+
+/** On recovery: remove the override created for this (agent, metric), if any. Returns the removed id. */
+export async function applyRecovery(
+  db: Db,
+  agentId: string,
+  metric: string,
+  tracker: OverrideTracker,
+): Promise<string | null> {
+  const id = tracker.take(overrideKey(agentId, metric));
+  if (id === undefined) return null;
+  await db.delete(overrides).where(eq(overrides.id, id));
+  return id;
+}
+
+/**
+ * Router for the AgentLens reactive-guardrails webhook.
+ * Mount before the user-auth middleware; it authenticates with a shared secret.
+ */
+export function createGuardrailsRouter(opts?: {
+  secret?: string;
+  rules?: GuardrailRule[];
+  tracker?: OverrideTracker;
+}) {
+  const secret = opts?.secret ?? process.env.GUARDRAILS_WEBHOOK_SECRET;
+  const rules = opts?.rules ?? loadRulesFromEnv();
+  const tracker = opts?.tracker ?? new OverrideTracker();
+  const router = new Hono();
+
+  // POST /api/guardrails/webhook — AgentLens breach/recovery alert.
+  router.post("/webhook", async (c) => {
+    // Fail closed: reject everything if no secret is configured.
+    if (!secret || c.req.header("x-guardrails-secret") !== secret) {
+      return c.json({ error: "unauthorized" }, 401);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as Partial<WebhookPayload> | null;
+    if (
+      !body ||
+      (body.event !== "breach" && body.event !== "recovery") ||
+      typeof body.metric !== "string" ||
+      typeof body.agentId !== "string"
+    ) {
+      return c.json({ error: "invalid payload" }, 400);
+    }
+
+    const rule = matchRule(body.metric, rules);
+    if (!rule) return c.json({ status: "ignored", reason: "no matching rule" }, 200);
+
+    if (body.event === "breach") {
+      const id = await applyBreach(getDb(), rule, body.agentId, tracker);
+      return c.json({ status: "override_created", overrideId: id }, 200);
+    }
+
+    const removed = await applyRecovery(getDb(), body.agentId, body.metric, tracker);
+    return c.json(
+      removed
+        ? { status: "override_removed", overrideId: removed }
+        : { status: "ignored", reason: "no active override" },
+      200,
+    );
+  });
+
+  return router;
+}
+
+export default createGuardrailsRouter;


### PR DESCRIPTION
## What (Phase D — shrink the ecosystem)
Folds the standalone **`agentkit-guardrails`** service into AgentGate as a native feature, so it can be **archived**. Removes a separate deployment and the AgentLens→guardrails→AgentGate HTTP hop — AgentGate now reacts to AgentLens metric alerts in-process.

## How it works
AgentLens threshold monitors `POST /api/guardrails/webhook` (shared-secret auth):
- **breach** of a configured metric → create a `require_approval` policy **override** for the rule's `toolPattern` (with optional TTL)
- **recovery** → remove that override

```
AgentLens (metrics) --breach/recovery webhook--> AgentGate /api/guardrails/webhook --> policy override (require approval)
```

## Changes
- **`routes/guardrails.ts`** — the webhook + rules engine. Auth is a shared secret (`x-guardrails-secret`), **fail closed** if unset. Override create/remove reuse the existing `overrides` table in-process. Core logic (`matchRule`, `applyBreach`, `applyRecovery`, `OverrideTracker`) takes a db handle, so it's unit-testable.
- **`index.ts`** — mounted before `app.use("/api/*", authMiddleware)` (a service webhook, like `/api/decide`).
- **`CONFIG.md`** — `GUARDRAILS_WEBHOOK_SECRET` + `GUARDRAILS_RULES` (JSON).

## Notes
- AgentGate's override model is **`require_approval` only**, so that's the action. The standalone's `deny`/`allow` actions never actually worked against `POST /api/overrides` (same validation), so nothing is lost.
- The `overrides` table comment already anticipated this (*"dynamic policy overrides, e.g. from AgentLens threshold alerts"*).

## Verified
- `tsc --noEmit` clean; lint clean on the new files.
- **6/6** new guardrails tests pass; **601/602** server tests pass — the 1 failure is the pre-existing `RedisRateLimiter` test that needs a live Redis (fails locally without one; unrelated to this change).

## Follow-up (yours)
Once merged, **archive `agentkitai/agentkit-guardrails`** (and `agentkit-mesh`). Ecosystem-table + org-profile updates are coming in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)