### PR TITLE
feat: MCP-registry artifacts + OWASP-tagged audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,29 @@ auto-deny dangerous ones, and route everything else to a human — via dashboard
 - 👥 **Multi-channel approvals** — Slack, Discord, email, or web dashboard
 - 🔌 **TypeScript SDK + MCP** — works with any agent framework or Claude Desktop
 - 🪝 **Webhooks with retry** — real-time notifications with exponential backoff
-- 📝 **Full audit trail** — every request, decision, and action logged
+- 📝 **Full audit trail** — every request, decision, and action logged, each policy decision tagged with the **OWASP LLM Top-10** risk it mitigates (compliance evidence)
 - 🐳 **Docker-ready** — one `docker-compose up` for the full stack
 - 🔐 **Production-hardened** — SSRF protection, ReDoS defense, structured logging, graceful shutdown
 - 🔗 **One-click decision links** — approve or deny directly from notification emails and webhooks
 - ♿ **Accessible UI** — keyboard-navigable approval modals, focus trapping, ARIA labels
 - 💀 **Skeleton loading** — smooth loading states across every dashboard page
 - ⚡ **Fast & lightweight** — Hono server, SQLite or PostgreSQL
+
+## Quickstart
+
+```bash
+# Self-host the full stack (server + dashboard + Postgres):
+docker compose up
+
+# …or from source:
+pnpm install && pnpm migrate && pnpm bootstrap && pnpm dev
+```
+
+Drop AgentGate into an MCP client (Claude Desktop / Cursor / VS Code) — point it at the gateway:
+
+```jsonc
+{ "mcpServers": { "agentgate": { "command": "npx", "args": ["@agentgate/mcp"] } } }
+```
 
 #### Dashboard
 See all pending requests at a glance, color-coded by urgency so you know what needs attention first.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agentgate/mcp",
   "version": "0.0.1",
+  "mcpName": "io.github.agentkitai/agentgate",
   "type": "module",
   "bin": {
     "agentgate-mcp": "./dist/index.js"

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.agentkitai/agentgate",
+  "description": "Human-in-the-loop approval gateway for AI agents: agents request, policies decide, humans approve — over MCP.",
+  "title": "AgentGate",
+  "websiteUrl": "https://github.com/agentkitai/agentgate",
+  "repository": {
+    "url": "https://github.com/agentkitai/agentgate",
+    "source": "github"
+  },
+  "version": "0.0.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@agentgate/mcp",
+      "version": "0.0.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/packages/server/src/__tests__/owasp.test.ts
+++ b/packages/server/src/__tests__/owasp.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+
+import { OWASP_LLM, owaspRiskForPolicyDecision } from "../lib/owasp.js";
+
+describe("owaspRiskForPolicyDecision", () => {
+  it("tags gated / escalated decisions as Excessive Agency (LLM06)", () => {
+    expect(owaspRiskForPolicyDecision("auto_deny")).toBe(OWASP_LLM.EXCESSIVE_AGENCY);
+    expect(owaspRiskForPolicyDecision("deny")).toBe(OWASP_LLM.EXCESSIVE_AGENCY);
+    expect(owaspRiskForPolicyDecision("route_to_human")).toBe(OWASP_LLM.EXCESSIVE_AGENCY);
+    expect(owaspRiskForPolicyDecision("ask")).toBe(OWASP_LLM.EXCESSIVE_AGENCY);
+  });
+
+  it("does not tag auto-approved (within-policy) actions", () => {
+    expect(owaspRiskForPolicyDecision("auto_approve")).toBeUndefined();
+    expect(owaspRiskForPolicyDecision("unknown")).toBeUndefined();
+  });
+});

--- a/packages/server/src/lib/owasp.ts
+++ b/packages/server/src/lib/owasp.ts
@@ -1,0 +1,28 @@
+// @agentgate/server — OWASP LLM Top-10 (2025) risk tagging for the audit trail.
+//
+// Tagging each policy decision with the OWASP LLM risk it addresses turns the
+// approval audit log into compliance evidence (filterable/exportable per risk).
+// Gating or escalating an agent's tool action is fundamentally an Excessive
+// Agency (LLM06) control; auto-approved actions were within policy bounds, so
+// they carry no tag.
+
+export const OWASP_LLM = {
+  EXCESSIVE_AGENCY: "LLM06:2025 Excessive Agency",
+  UNBOUNDED_CONSUMPTION: "LLM10:2025 Unbounded Consumption",
+} as const;
+
+/**
+ * Map an approval-gateway policy decision to the OWASP LLM Top-10 risk it
+ * mitigates. Returns undefined when no risk is flagged (e.g. auto-approve).
+ */
+export function owaspRiskForPolicyDecision(decision: string): string | undefined {
+  switch (decision) {
+    case "auto_deny":
+    case "deny":
+    case "route_to_human":
+    case "ask":
+      return OWASP_LLM.EXCESSIVE_AGENCY;
+    default:
+      return undefined;
+  }
+}

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -15,6 +15,7 @@ import {
   type RequestDecidedEvent,
 } from "@agentgate/core";
 import { logAuditEvent } from "../lib/audit.js";
+import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
 import { deliverWebhook } from "../lib/webhook.js";
 import { getGlobalDispatcher } from "../lib/notification/index.js";
 import { getCachedPolicies } from "../lib/policy-cache.js";
@@ -274,6 +275,9 @@ requestsRouter.post("/", async (c) => {
     urgency,
     policyDecision: policyDecision.decision,
     matchedRule: policyDecision.matchedRule,
+    // Compliance evidence: tag the decision with the OWASP LLM risk it
+    // mitigates (gating/escalating a tool action = LLM06 Excessive Agency).
+    owaspRisk: owaspRiskForPolicyDecision(policyDecision.decision),
   });
 
   // Emit request.created event


### PR DESCRIPTION
Two Tier-1 items for AgentGate.

## Item 1 — distribution
- **`packages/mcp/package.json`**: add `mcpName: "io.github.agentkitai/agentgate"`.
- **`packages/mcp/server.json`**: MCP-registry manifest (`2025-12-11` schema, npm `@agentgate/mcp`).
- **`README.md`**: a prominent **Quickstart** (one `docker compose up`, or `pnpm install && pnpm migrate && pnpm bootstrap && pnpm dev`) + the MCP client config one-liner — the README previously had only a 6-step setup.

## Item 3 — compliance
Every policy decision in the audit trail is now tagged with the **OWASP LLM Top-10 (2025)** risk it mitigates — turning the approval log into compliance evidence.
- **`lib/owasp.ts`**: OWASP constants + `owaspRiskForPolicyDecision()` — gating/escalating a tool action is fundamentally **LLM06 Excessive Agency**; auto-approved (within-policy) actions carry no tag. + a unit test.
- **`routes/requests.ts`**: stamp `owaspRisk` onto the policy-decision audit `details` (JSON — no schema change, exportable as-is).

## Validation
`tsc --noEmit` clean, eslint clean, `audit-api` tests + the new `owasp` test pass. (The one flaky failure in a local full run is the Redis-less rate-limiter test, unrelated.)

## Follow-ups / outward steps (owner)
- Publish `@agentgate/mcp` to npm (it's at `0.0.1`, unpublished), then `mcp-publisher` to list.
- Guardrail-breach tagging (agent-level, cost/rate → LLM10) needs a non-request-scoped audit channel — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)