### PR TITLE
chore: release @agentgate/mcp 0.0.2 (carry mcpName into the published package)

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentgate/mcp",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "mcpName": "io.github.agentkitai/agentgate",
   "type": "module",
   "bin": {

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/agentkitai/agentgate",
     "source": "github"
   },
-  "version": "0.0.1",
+  "version": "0.0.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@agentgate/mcp",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump so AgentGate's MCP server can be published to the MCP Registry.

**Why:** the registry verifies the `mcpName` field **in the published npm package**, but `@agentgate/mcp 0.0.1` on npm predates it (added in #7) and npm versions are immutable. Bump to **0.0.2** so a fresh release carries it.

- `packages/mcp/package.json`: `0.0.1 → 0.0.2`
- `packages/mcp/server.json`: top-level + `packages[].version` → `0.0.2`

**Release steps (owner, after merge):**
1. `pnpm --filter @agentgate/mcp publish --access public` (npm).
2. `mcp-publisher login github && mcp-publisher publish` from `packages/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)