### PR TITLE
fix: npm provenance repository + registry description <=100

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,6 +2,11 @@
   "name": "@agentgate/mcp",
   "version": "0.0.2",
   "mcpName": "io.github.agentkitai/agentgate",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agentkitai/agentgate.git",
+    "directory": "packages/mcp"
+  },
   "type": "module",
   "bin": {
     "agentgate-mcp": "./dist/index.js"

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.agentkitai/agentgate",
-  "description": "Human-in-the-loop approval gateway for AI agents: agents request, policies decide, humans approve — over MCP.",
+  "description": "Human-in-the-loop approval gateway for AI agents over MCP: request, decide, approve.",
   "title": "AgentGate",
   "websiteUrl": "https://github.com/agentkitai/agentgate",
   "repository": {


### PR DESCRIPTION
The \`mcp-v0.0.2\` dispatch built cleanly (core-then-mcp fix worked) but **npm publish failed E422**:

\`\`\`
Error verifying sigstore provenance bundle: package.json: "repository.url" is "",
expected to match "https://github.com/agentkitai/agentgate" from provenance
\`\`\`

OIDC trusted publishing signs a provenance statement and npm requires \`package.json.repository.url\` to match the source repo. It was missing.

**Fixes:**
1. Add \`repository\` (url + \`directory: packages/mcp\`) to \`packages/mcp/package.json\`.
2. Trim \`server.json\` description to <=100 (the MCP registry rejected 111, same as lore).

\`@agentgate/mcp\` is still 0.0.1 on npm — nothing was half-published. I'll re-dispatch after merge: build → npm publish 0.0.2 → registry listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)