### PR TITLE
feat(server): OAuth2 client-credentials tokens for agents (#12)

### DIFF
--- a/packages/server/src/__tests__/agent-tokens.test.ts
+++ b/packages/server/src/__tests__/agent-tokens.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Agent OAuth2 client-credentials token endpoint + token helpers (#12, PR2).
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import { signAccessToken, type AuthConfig } from "agentkit-auth";
+import * as schema from "../db/schema.js";
+
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+
+sqlite.exec(`
+CREATE TABLE IF NOT EXISTS agents (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  secret_hash text NOT NULL,
+  status text NOT NULL,
+  metadata text,
+  created_at integer NOT NULL,
+  last_seen_at integer,
+  revoked_at integer
+);
+`);
+
+vi.mock("../db/index.js", () => ({ getDb: () => db }));
+
+import { createAgent, revokeAgent, getAgentIfActive } from "../lib/agents.js";
+import {
+  signAgentToken,
+  verifyAgentToken,
+  resolveVerifiedAgentId,
+} from "../lib/agent-tokens.js";
+import agentTokenRouter from "../routes/agent-tokens.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const TEST_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+
+/** Standalone AuthConfig for the pure-lib JWT tests (no config singleton). */
+function authConfig(secret = TEST_SECRET): AuthConfig {
+  return {
+    oidc: null,
+    jwt: { secret, accessTokenTtlSeconds: 900, refreshTokenTtlSeconds: 604800 },
+    authDisabled: false,
+  };
+}
+
+function app() {
+  const a = new Hono();
+  a.route("/api/agents/token", agentTokenRouter);
+  return a;
+}
+
+async function postToken(body: Record<string, unknown>, headers: Record<string, string> = {}) {
+  return app().request("/api/agents/token", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM agents");
+  setConfig(parseConfig({ jwtSecret: TEST_SECRET })); // authMode defaults to "dual"
+});
+
+afterAll(() => {
+  resetConfig();
+  sqlite.close();
+});
+
+describe("agent-tokens lib", () => {
+  it("round-trips a minted agent token back to its agent id", async () => {
+    const t = await signAgentToken("agt_abc", authConfig());
+    expect(await verifyAgentToken(t, authConfig())).toBe("agt_abc");
+  });
+
+  it("rejects a USER token (no typ:agent) — prevents cross-over", async () => {
+    const userTok = await signAccessToken(
+      { sub: "user_1", tid: "default", role: "admin", email: "u@x.io" },
+      authConfig(),
+    );
+    expect(await verifyAgentToken(userTok, authConfig())).toBeNull();
+  });
+
+  it("rejects a tampered token, a wrong-secret token, and undefined", async () => {
+    const t = await signAgentToken("agt_abc", authConfig());
+    expect(await verifyAgentToken(`${t.slice(0, -2)}xx`, authConfig())).toBeNull();
+    const fromOther = await signAgentToken("agt_abc", authConfig("a-totally-different-secret-32-chars-x"));
+    expect(await verifyAgentToken(fromOther, authConfig())).toBeNull();
+    expect(await verifyAgentToken(undefined, authConfig())).toBeNull();
+  });
+});
+
+describe("POST /api/agents/token", () => {
+  it("mints a Bearer token for a valid JSON credential", async () => {
+    const { agent, secret } = await createAgent("ci");
+    const res = await postToken({
+      grant_type: "client_credentials",
+      client_id: agent.id,
+      client_secret: secret,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBe(900);
+    expect(typeof body.access_token).toBe("string");
+    expect(await verifyAgentToken(body.access_token as string, authConfig())).toBe(agent.id);
+  });
+
+  it("accepts HTTP Basic credentials", async () => {
+    const { agent, secret } = await createAgent("ci");
+    const basic = Buffer.from(`${agent.id}:${secret}`).toString("base64");
+    const res = await postToken({ grant_type: "client_credentials" }, { authorization: `Basic ${basic}` });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 invalid_client for bad secret AND unknown id (no enumeration)", async () => {
+    const { agent } = await createAgent("ci");
+    const bad = await postToken({
+      grant_type: "client_credentials",
+      client_id: agent.id,
+      client_secret: "ags_wrong",
+    });
+    expect(bad.status).toBe(401);
+    expect(((await bad.json()) as { error: string }).error).toBe("invalid_client");
+
+    const missing = await postToken({
+      grant_type: "client_credentials",
+      client_id: "agt_nope",
+      client_secret: "ags_x",
+    });
+    expect(missing.status).toBe(401);
+    expect(((await missing.json()) as { error: string }).error).toBe("invalid_client");
+  });
+
+  it("returns 401 for a revoked agent", async () => {
+    const { agent, secret } = await createAgent("ci");
+    await revokeAgent(agent.id);
+    const res = await postToken({
+      grant_type: "client_credentials",
+      client_id: agent.id,
+      client_secret: secret,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 unsupported_grant_type for a missing grant", async () => {
+    const { agent, secret } = await createAgent("ci");
+    const res = await postToken({ client_id: agent.id, client_secret: secret });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("unsupported_grant_type");
+  });
+
+  it("returns 400 in api-key-only mode (JWT disabled)", async () => {
+    setConfig(parseConfig({ jwtSecret: TEST_SECRET, authMode: "api-key-only" }));
+    const { agent, secret } = await createAgent("ci");
+    const res = await postToken({
+      grant_type: "client_credentials",
+      client_id: agent.id,
+      client_secret: secret,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("use-time revocation (the requests-route guard)", () => {
+  it("a still-valid token stops resolving once the agent is revoked", async () => {
+    const { agent } = await createAgent("ci");
+    const token = await signAgentToken(agent.id, authConfig());
+    expect(await verifyAgentToken(token, authConfig())).toBe(agent.id); // signature still valid
+    await revokeAgent(agent.id);
+    expect(await getAgentIfActive(agent.id)).toBeNull(); // ...but the use-time check rejects it
+  });
+
+  it("getAgentIfActive returns the id for active, null for missing", async () => {
+    const { agent } = await createAgent("ci");
+    expect(await getAgentIfActive(agent.id)).toBe(agent.id);
+    expect(await getAgentIfActive("agt_missing")).toBeNull();
+  });
+});
+
+// resolveVerifiedAgentId is exactly the logic POST /api/requests runs to stamp
+// verifiedAgentId, so testing it here covers that route branch end-to-end.
+describe("resolveVerifiedAgentId", () => {
+  it("resolves a fresh agent Bearer token to its agent id", async () => {
+    const { agent } = await createAgent("ci");
+    const token = await signAgentToken(agent.id, authConfig());
+    expect(await resolveVerifiedAgentId({ agentToken: token }, "dual")).toBe(agent.id);
+  });
+
+  it("token takes precedence over legacy X-Agent-Id/Secret headers", async () => {
+    const a = await createAgent("a");
+    const b = await createAgent("b");
+    const tokenA = await signAgentToken(a.agent.id, authConfig());
+    const resolved = await resolveVerifiedAgentId(
+      { agentToken: tokenA, agentId: b.agent.id, agentSecret: b.secret },
+      "dual",
+    );
+    expect(resolved).toBe(a.agent.id);
+  });
+
+  it("falls back to legacy header creds when the token is for a revoked agent", async () => {
+    const tokenAgent = await createAgent("tok");
+    const legacyAgent = await createAgent("leg");
+    const token = await signAgentToken(tokenAgent.agent.id, authConfig());
+    await revokeAgent(tokenAgent.agent.id); // token signature valid, but agent revoked
+    const resolved = await resolveVerifiedAgentId(
+      { agentToken: token, agentId: legacyAgent.agent.id, agentSecret: legacyAgent.secret },
+      "dual",
+    );
+    expect(resolved).toBe(legacyAgent.agent.id);
+  });
+
+  it("returns null for a revoked-agent token with no legacy fallback", async () => {
+    const { agent } = await createAgent("ci");
+    const token = await signAgentToken(agent.id, authConfig());
+    await revokeAgent(agent.id);
+    expect(await resolveVerifiedAgentId({ agentToken: token }, "dual")).toBeNull();
+  });
+
+  it("ignores a USER token in the X-Agent-Token slot (no cross-over)", async () => {
+    const userTok = await signAccessToken(
+      { sub: "user_1", tid: "default", role: "admin", email: "u@x.io" },
+      authConfig(),
+    );
+    expect(await resolveVerifiedAgentId({ agentToken: userTok }, "dual")).toBeNull();
+  });
+
+  it("ignores a valid token in api-key-only mode (forgery gate)", async () => {
+    const { agent } = await createAgent("ci");
+    const token = await signAgentToken(agent.id, authConfig());
+    // token would otherwise resolve, but the mode disables the token path
+    expect(await resolveVerifiedAgentId({ agentToken: token }, "api-key-only")).toBeNull();
+  });
+
+  it("resolves legacy header creds when no token is present", async () => {
+    const { agent, secret } = await createAgent("ci");
+    expect(
+      await resolveVerifiedAgentId({ agentId: agent.id, agentSecret: secret }, "dual"),
+    ).toBe(agent.id);
+  });
+
+  it("returns null when nothing is presented", async () => {
+    expect(await resolveVerifiedAgentId({}, "dual")).toBeNull();
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,6 +11,7 @@ import requestsRouter from "./routes/requests.js";
 import policiesRouter from "./routes/policies.js";
 import apiKeysRouter from "./routes/api-keys.js";
 import agentsRouter from "./routes/agents.js";
+import agentTokenRouter from "./routes/agent-tokens.js";
 import webhooksRouter from "./routes/webhooks.js";
 import auditRouter from "./routes/audit.js";
 import analyticsRouter from "./routes/analytics.js";
@@ -184,6 +185,10 @@ app.route("/api/guardrails", createGuardrailsRouter());
 // Auth routes (mostly public — login, callback, refresh, logout)
 // /auth/me requires auth and is handled inside the router
 app.route("/auth", authRouter);
+
+// Agent OAuth2 token endpoint (public — the agent's own agt_*/ags_* credential
+// is the auth). Must be mounted before the user-auth middleware below.
+app.route("/api/agents/token", agentTokenRouter);
 
 // Apply auth middleware to all /api/* routes
 app.use("/api/*", authMiddleware);

--- a/packages/server/src/lib/agent-tokens.ts
+++ b/packages/server/src/lib/agent-tokens.ts
@@ -1,0 +1,64 @@
+// @agentgate/server — Agent OAuth2 token helpers (agent-identity spine).
+//
+// An agent exchanges its long-lived secret (ags_*) once at the token endpoint
+// for a short-lived Bearer JWT, then presents the JWT (X-Agent-Token) instead
+// of sending the secret on every call. Tokens are signed with the SAME
+// JWT_SECRET and helpers as user sessions; a `typ:"agent"` claim is the sole
+// discriminator that keeps an agent token from being accepted as a user
+// session (and vice versa) — verifyAccessToken only checks the signature, not
+// the claim, so this check is load-bearing and must not be dropped.
+
+import { signAccessToken, verifyAccessToken, type AuthConfig } from "agentkit-auth";
+
+import { getAgentIfActive, verifyAgentCredential } from "./agents.js";
+import { getAuthConfig } from "./auth-config.js";
+
+export const AGENT_TOKEN_TYP = "agent";
+
+/** Mint a short-lived agent access token. sub = agt_* id; exp from config TTL. */
+export async function signAgentToken(agentId: string, config: AuthConfig): Promise<string> {
+  // tid/role/email satisfy AccessTokenClaims' required fields but are inert:
+  // agent tokens never flow through the user RBAC path (see middleware/auth.ts).
+  return signAccessToken(
+    { sub: agentId, tid: "default", role: "viewer", email: "", typ: AGENT_TOKEN_TYP },
+    config,
+  );
+}
+
+/**
+ * Verify a Bearer token AS an agent token. Returns the agent id (sub) iff the
+ * signature is valid AND typ === "agent"; otherwise null — including for valid
+ * USER tokens, which must never cross over into the agent path.
+ */
+export async function verifyAgentToken(
+  token: string | undefined,
+  config: AuthConfig,
+): Promise<string | null> {
+  if (!token) return null;
+  const claims = await verifyAccessToken(token, config);
+  if (!claims) return null;
+  if ((claims as Record<string, unknown>).typ !== AGENT_TOKEN_TYP) return null;
+  return typeof claims.sub === "string" ? claims.sub : null;
+}
+
+/**
+ * Resolve the VERIFIED agent id for an inbound request, or null. Prefers a
+ * short-lived agent Bearer token (X-Agent-Token); falls back to the legacy
+ * long-lived X-Agent-Id / X-Agent-Secret headers. The token path is disabled
+ * in api-key-only mode, where the JWT signing secret is the public dev
+ * placeholder and a token would therefore be forgeable.
+ */
+export async function resolveVerifiedAgentId(
+  creds: { agentToken?: string; agentId?: string; agentSecret?: string },
+  authMode: string,
+): Promise<string | null> {
+  if (authMode !== "api-key-only" && creds.agentToken) {
+    const tokenAgentId = await verifyAgentToken(creds.agentToken, getAuthConfig());
+    // Re-check active status at USE time: a stateless token can outlive a revoke.
+    if (tokenAgentId) {
+      const live = await getAgentIfActive(tokenAgentId);
+      if (live) return live;
+    }
+  }
+  return (await verifyAgentCredential(creds.agentId, creds.agentSecret))?.id ?? null;
+}

--- a/packages/server/src/lib/agents.ts
+++ b/packages/server/src/lib/agents.ts
@@ -98,6 +98,20 @@ export async function listAgents(): Promise<PublicAgent[]> {
   return rows.map(toPublic);
 }
 
+/**
+ * Active-status check by id only (no secret). Used to re-validate an agent
+ * Bearer token at USE time, since a stateless JWT can outlive a revoke.
+ * Returns the id iff the agent still exists and is active; otherwise null.
+ */
+export async function getAgentIfActive(id: string): Promise<string | null> {
+  const rows = await getDb()
+    .select({ id: agents.id, status: agents.status })
+    .from(agents)
+    .where(and(eq(agents.id, id), isNull(agents.revokedAt)))
+    .limit(1);
+  return rows[0]?.status === "active" ? rows[0].id : null;
+}
+
 /** Revoke an agent. Returns false if it doesn't exist or is already revoked. */
 export async function revokeAgent(id: string): Promise<boolean> {
   const rows = await getDb()

--- a/packages/server/src/lib/auth-config.ts
+++ b/packages/server/src/lib/auth-config.ts
@@ -1,0 +1,28 @@
+// @agentgate/server — Assemble the agentkit-auth AuthConfig from server config.
+// Shared by the agent token endpoint and agent Bearer verification on the
+// requests route. (routes/auth.ts + middleware/auth.ts keep their own copies
+// for now; consolidating those is a separate cleanup.)
+
+import { getConfig, resolveJwtSecret } from "../config.js";
+import type { AuthConfig } from "agentkit-auth";
+
+export function getAuthConfig(): AuthConfig {
+  const config = getConfig();
+  return {
+    oidc: config.oidcIssuer
+      ? {
+          issuerUrl: config.oidcIssuer,
+          clientId: config.oidcClientId || "",
+          clientSecret: config.oidcClientSecret || "",
+          redirectUri: config.oidcRedirectUri || "",
+          scopes: ["openid", "profile", "email"],
+        }
+      : null,
+    jwt: {
+      secret: resolveJwtSecret(config),
+      accessTokenTtlSeconds: config.jwtAccessTtl,
+      refreshTokenTtlSeconds: config.jwtRefreshTtl,
+    },
+    authDisabled: false,
+  };
+}

--- a/packages/server/src/routes/agent-tokens.ts
+++ b/packages/server/src/routes/agent-tokens.ts
@@ -1,0 +1,84 @@
+// @agentgate/server — Agent OAuth2 token endpoint (agent-identity spine).
+//
+// POST /api/agents/token — RFC 6749 client_credentials grant. An agent presents
+// its agt_*/ags_* credential (JSON body or HTTP Basic) and receives a
+// short-lived Bearer JWT to use as X-Agent-Token. PUBLIC: mounted before the
+// user-auth middleware — the agent's own credential is the authentication.
+
+import { Hono, type Context } from "hono";
+
+import { verifyAgentCredential } from "../lib/agents.js";
+import { signAgentToken } from "../lib/agent-tokens.js";
+import { getAuthConfig } from "../lib/auth-config.js";
+import { getConfig } from "../config.js";
+
+const router = new Hono();
+
+/** Pull client_id/client_secret/grant_type from HTTP Basic (preferred) or body. */
+async function parseCredentials(c: Context): Promise<{
+  clientId?: string;
+  clientSecret?: string;
+  grantType?: string;
+}> {
+  let clientId: string | undefined;
+  let clientSecret: string | undefined;
+
+  const authz = c.req.header("authorization");
+  if (authz?.startsWith("Basic ")) {
+    const decoded = Buffer.from(authz.slice(6), "base64").toString("utf-8");
+    const i = decoded.indexOf(":");
+    if (i >= 0) {
+      clientId = decoded.slice(0, i);
+      clientSecret = decoded.slice(i + 1);
+    }
+  }
+
+  let grantType: string | undefined;
+  const ctype = c.req.header("content-type") ?? "";
+  if (ctype.includes("application/json")) {
+    const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+    grantType = typeof body.grant_type === "string" ? body.grant_type : undefined;
+    clientId ??= typeof body.client_id === "string" ? body.client_id : undefined;
+    clientSecret ??= typeof body.client_secret === "string" ? body.client_secret : undefined;
+  } else {
+    // RFC 6749 norm: application/x-www-form-urlencoded.
+    const form = await c.req.parseBody().catch(() => ({}) as Record<string, unknown>);
+    grantType = typeof form.grant_type === "string" ? form.grant_type : undefined;
+    clientId ??= typeof form.client_id === "string" ? form.client_id : undefined;
+    clientSecret ??= typeof form.client_secret === "string" ? form.client_secret : undefined;
+  }
+
+  return { clientId, clientSecret, grantType };
+}
+
+router.post("/", async (c) => {
+  if (getConfig().authMode === "api-key-only") {
+    return c.json(
+      {
+        error: "unsupported_grant_type",
+        error_description: "JWT auth is disabled (AUTH_MODE=api-key-only)",
+      },
+      400,
+    );
+  }
+
+  const { clientId, clientSecret, grantType } = await parseCredentials(c);
+  if (grantType !== "client_credentials") {
+    return c.json({ error: "unsupported_grant_type" }, 400);
+  }
+
+  const agent = await verifyAgentCredential(clientId, clientSecret);
+  if (!agent) {
+    // Identical response for unknown id vs bad/revoked secret — no enumeration.
+    return c.json({ error: "invalid_client" }, 401);
+  }
+
+  const token = await signAgentToken(agent.id, getAuthConfig());
+  return c.json({
+    access_token: token,
+    token_type: "Bearer",
+    expires_in: getConfig().jwtAccessTtl,
+  });
+});
+
+export default router;

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -16,7 +16,8 @@ import {
 } from "@agentgate/core";
 import { logAuditEvent } from "../lib/audit.js";
 import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
-import { verifyAgentCredential } from "../lib/agents.js";
+import { resolveVerifiedAgentId } from "../lib/agent-tokens.js";
+import { getConfig } from "../config.js";
 import { deliverWebhook } from "../lib/webhook.js";
 import { getGlobalDispatcher } from "../lib/notification/index.js";
 import { getCachedPolicies } from "../lib/policy-cache.js";
@@ -252,15 +253,19 @@ requestsRouter.post("/", async (c) => {
   }
   // route_to_human and route_to_agent stay pending
 
-  // Agent-identity spine: verify an optional agent credential (X-Agent-Id +
-  // X-Agent-Secret) and resolve the VERIFIED agent id — distinct from the
-  // caller-claimed context.agentId, which is unauthenticated. Null when none
-  // is presented or it fails to verify.
-  const verifiedAgentId =
-    (await verifyAgentCredential(
-      c.req.header("x-agent-id"),
-      c.req.header("x-agent-secret"),
-    ))?.id ?? null;
+  // Agent-identity spine: resolve the VERIFIED agent id — distinct from the
+  // caller-claimed context.agentId, which is unauthenticated. Prefers a
+  // short-lived agent Bearer token (X-Agent-Token from POST /api/agents/token)
+  // over the legacy X-Agent-Id / X-Agent-Secret headers. Null when neither is
+  // presented or verification fails.
+  const verifiedAgentId = await resolveVerifiedAgentId(
+    {
+      agentToken: c.req.header("x-agent-token"),
+      agentId: c.req.header("x-agent-id"),
+      agentSecret: c.req.header("x-agent-secret"),
+    },
+    getConfig().authMode,
+  );
 
   // Insert into database
   await getDb().insert(approvalRequests).values({


### PR DESCRIPTION
## Agent-identity spine — PR2: OAuth2 client-credentials tokens

Builds on #15 (registry + verified stamping). An agent exchanges its long-lived secret (`ags_*`) **once** for a short-lived Bearer JWT, then presents the token instead of the secret on every call — the secret stops travelling on the wire per-request.

### What's in
- **`lib/agent-tokens`** — `signAgentToken` / `verifyAgentToken`, reusing the existing `signAccessToken` / `verifyAccessToken` + `JWT_SECRET` (**no new crypto or key**). A `typ:"agent"` claim is the *sole* discriminator keeping agent and user tokens from crossing over — `verifyAccessToken` checks only the HS256 signature, so that claim check is load-bearing.
- **`routes/agent-tokens`** — `POST /api/agents/token`, RFC 6749 `client_credentials` (JSON body **or** HTTP Basic). Public, mounted before the user-auth middleware (the agent's own credential is the auth). Returns `{ access_token, token_type: "Bearer", expires_in }`. `401 invalid_client` for bad/unknown/revoked credentials (identical response — no enumeration); `400 unsupported_grant_type` otherwise.
- **`lib/auth-config`** — shared `getAuthConfig()` for the new consumers.
- **`requests` route** — `resolveVerifiedAgentId` prefers `X-Agent-Token`, **re-checks the agent is still active at use time** (a stateless token can outlive a revoke), and falls back to the legacy `X-Agent-Id` / `X-Agent-Secret` headers.

### Security
- **Forgery gate**: the token path is disabled in `api-key-only` mode, where `resolveJwtSecret` returns the *public* dev placeholder — a token signed with it would otherwise be forgeable. The token endpoint `400`s in that mode and the requests route ignores `X-Agent-Token`.
- **Cross-over** is blocked both directions: a user JWT presented as `X-Agent-Token` resolves to null (`typ` check), and an agent token fails `authMiddleware`'s user lookup, so it can't become a session.
- **Revocation** enforced at issue time (`verifyAgentCredential`) and at use time (`getAgentIfActive`).
- No secret or token is logged. No new DB tables (stateless JWT). Token issuance isn't audited because the audit table is request-scoped (FK to `approval_requests`); `lastSeenAt` already records the auth.

### Tests (19)
mint/verify round-trip; the `typ` cross-over guard both directions; tamper / wrong-secret; the endpoint (JSON + Basic, bad/unknown/revoked → 401, missing grant → 400, api-key-only → 400); and `resolveVerifiedAgentId` — the exact logic `POST /api/requests` runs — covering token precedence over legacy headers, use-time-revocation fallback, the api-key-only forgery gate, user-token rejection, and legacy fallback.

`vitest run` → **625 passing**; the one failure is the env-dependent Redis-fallback test (a real Redis is reachable locally), unrelated. typecheck + eslint clean.

### Reviewed
Ran an adversarial multi-agent review of the diff (routing/mount, auth/security, OAuth contract, test gaps). It surfaced no code defects; its one confirmed finding — the `X-Agent-Token` route branch lacked a unit — is closed in this PR by extracting that logic into the tested `resolveVerifiedAgentId`.

Closes part of #12. Follow-up: consolidate the three `getAuthConfig()` copies (auth route, middleware, this lib); per-agent rate-limiting on the grant endpoint.
