### PR TITLE
feat(server): virtual keys — agent-scoped API keys (#13)

### DIFF
--- a/packages/server/drizzle/postgres/0005_furry_wallow.sql
+++ b/packages/server/drizzle/postgres/0005_furry_wallow.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "api_keys" ADD COLUMN "agent_id" text;

--- a/packages/server/drizzle/postgres/meta/0005_snapshot.json
+++ b/packages/server/drizzle/postgres/meta/0005_snapshot.json
@@ -1,0 +1,1114 @@
+{
+  "id": "26cb6c63-2153-4e69-89c3-e622bccb0968",
+  "prevId": "d2c0148b-d2d6-4bbd-a494-82a24ed0ce93",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decision_tokens": {
+      "name": "decision_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_history": {
+      "name": "escalation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_rules": {
+      "name": "escalation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overrides": {
+      "name": "overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policies": {
+      "name": "policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oidc_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/postgres/meta/_journal.json
+++ b/packages/server/drizzle/postgres/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782110290202,
       "tag": "0004_open_sharon_ventura",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1782115822907,
+      "tag": "0005_furry_wallow",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/sqlite/0008_fixed_puma.sql
+++ b/packages/server/drizzle/sqlite/0008_fixed_puma.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `api_keys` ADD `agent_id` text;

--- a/packages/server/drizzle/sqlite/meta/0008_snapshot.json
+++ b/packages/server/drizzle/sqlite/meta/0008_snapshot.json
@@ -1,0 +1,1041 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0375e417-c20a-4524-b143-ea01529651a3",
+  "prevId": "7943c8c2-55a6-464e-9508-1953528e3a9b",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approval_requests": {
+      "name": "approval_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_tokens": {
+      "name": "decision_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_history": {
+      "name": "escalation_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            "rule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_rules": {
+      "name": "escalation_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            "policy_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "overrides": {
+      "name": "overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refresh_tokens": {
+      "name": "refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": true
+        },
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/sqlite/meta/_journal.json
+++ b/packages/server/drizzle/sqlite/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782110288803,
       "tag": "0007_nappy_jack_flag",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1782115820508,
+      "tag": "0008_fixed_puma",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/api-key-cache.test.ts
+++ b/packages/server/src/__tests__/api-key-cache.test.ts
@@ -23,7 +23,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
   created_at integer NOT NULL,
   last_used_at integer,
   revoked_at integer,
-  rate_limit integer
+  rate_limit integer,
+  agent_id text
 );
 CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash);
 `);

--- a/packages/server/src/__tests__/audit-api.test.ts
+++ b/packages/server/src/__tests__/audit-api.test.ts
@@ -55,7 +55,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
   created_at integer NOT NULL,
   last_used_at integer,
   revoked_at integer,
-  rate_limit integer
+  rate_limit integer,
+  agent_id text
 );
 `;
 

--- a/packages/server/src/__tests__/auth-routes.test.ts
+++ b/packages/server/src/__tests__/auth-routes.test.ts
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS refresh_tokens (
 CREATE TABLE IF NOT EXISTS api_keys (
   id text PRIMARY KEY NOT NULL, key_hash text NOT NULL, name text NOT NULL,
   scopes text NOT NULL, created_at integer NOT NULL, last_used_at integer,
-  revoked_at integer, rate_limit integer
+  revoked_at integer, rate_limit integer, agent_id text
 );
 `;
 

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -64,7 +64,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
   created_at integer NOT NULL,
   last_used_at integer,
   revoked_at integer,
-  rate_limit integer
+  rate_limit integer,
+  agent_id text
 );
 
 CREATE TABLE IF NOT EXISTS webhooks (

--- a/packages/server/src/__tests__/integration/oidc-auth.test.ts
+++ b/packages/server/src/__tests__/integration/oidc-auth.test.ts
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS policies (
 CREATE TABLE IF NOT EXISTS api_keys (
   id text PRIMARY KEY NOT NULL, key_hash text NOT NULL, name text NOT NULL,
   scopes text NOT NULL, created_at integer NOT NULL, last_used_at integer,
-  revoked_at integer, rate_limit integer
+  revoked_at integer, rate_limit integer, agent_id text
 );
 CREATE TABLE IF NOT EXISTS webhooks (
   id text PRIMARY KEY NOT NULL, url text NOT NULL, secret text NOT NULL,

--- a/packages/server/src/__tests__/setup.ts
+++ b/packages/server/src/__tests__/setup.ts
@@ -66,7 +66,8 @@ CREATE TABLE IF NOT EXISTS \`api_keys\` (
 	\`created_at\` integer NOT NULL,
 	\`last_used_at\` integer,
 	\`revoked_at\` integer,
-	\`rate_limit\` integer
+	\`rate_limit\` integer,
+	\`agent_id\` text
 );
 
 CREATE TABLE IF NOT EXISTS \`webhook_deliveries\` (

--- a/packages/server/src/__tests__/tokens.test.ts
+++ b/packages/server/src/__tests__/tokens.test.ts
@@ -62,7 +62,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
   created_at integer NOT NULL,
   last_used_at integer,
   revoked_at integer,
-  rate_limit integer
+  rate_limit integer,
+  agent_id text
 );
 
 CREATE TABLE IF NOT EXISTS webhooks (

--- a/packages/server/src/__tests__/virtual-keys.test.ts
+++ b/packages/server/src/__tests__/virtual-keys.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Virtual keys — agent-scoped API keys (issue #13, PR1).
+ *
+ * reconcileBoundAgent (pure) is the enforcement decision POST /api/requests
+ * runs; the route tests cover issuance + the getAgentIfActive binding gate.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import * as schema from "../db/schema.js";
+
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+
+sqlite.exec(`
+CREATE TABLE IF NOT EXISTS api_keys (
+  id text PRIMARY KEY NOT NULL,
+  key_hash text NOT NULL,
+  name text NOT NULL,
+  scopes text NOT NULL,
+  created_at integer NOT NULL,
+  last_used_at integer,
+  revoked_at integer,
+  rate_limit integer,
+  agent_id text
+);
+CREATE TABLE IF NOT EXISTS agents (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  secret_hash text NOT NULL,
+  status text NOT NULL,
+  metadata text,
+  created_at integer NOT NULL,
+  last_seen_at integer,
+  revoked_at integer
+);
+`);
+
+// db/index re-exports the schema tables (lib/api-keys imports `apiKeys` from
+// here), so the mock must surface them alongside getDb.
+vi.mock("../db/index.js", async () => ({
+  ...(await vi.importActual<typeof import("../db/schema.js")>("../db/schema.js")),
+  getDb: () => db,
+}));
+
+import { createAgent, revokeAgent } from "../lib/agents.js";
+import { reconcileBoundAgent, resolveEffectiveAgentId } from "../lib/agent-tokens.js";
+import apiKeysRouter from "../routes/api-keys.js";
+
+function app() {
+  const a = new Hono();
+  // Stub the admin auth that requirePermission("keys:manage") checks.
+  a.use("*", async (c, next) => {
+    c.set("auth", {
+      identity: { type: "api_key", id: "k", displayName: "test", role: "admin" },
+      tenantId: "default",
+      permissions: ["*"],
+    });
+    await next();
+  });
+  a.route("/api/api-keys", apiKeysRouter);
+  return a;
+}
+
+function createKey(body: Record<string, unknown>) {
+  return app().request("/api/api-keys", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function persistedAgentId(keyId: string): unknown {
+  return (sqlite.prepare("SELECT agent_id FROM api_keys WHERE id = ?").get(keyId) as
+    | { agent_id: unknown }
+    | undefined)?.agent_id;
+}
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM api_keys");
+  sqlite.exec("DELETE FROM agents");
+});
+
+afterAll(() => sqlite.close());
+
+describe("reconcileBoundAgent", () => {
+  it("passes the verified id through for an unbound (legacy) key", () => {
+    expect(reconcileBoundAgent(null, null)).toEqual({ agentId: null });
+    expect(reconcileBoundAgent(null, "agt_x")).toEqual({ agentId: "agt_x" });
+  });
+  it("promotes the binding to verified when there is no separate claim", () => {
+    expect(reconcileBoundAgent("agt_x", null)).toEqual({ agentId: "agt_x" });
+  });
+  it("accepts a matching separate claim", () => {
+    expect(reconcileBoundAgent("agt_x", "agt_x")).toEqual({ agentId: "agt_x" });
+  });
+  it("conflicts when the verified claim names a different agent", () => {
+    expect(reconcileBoundAgent("agt_x", "agt_y")).toEqual({ conflict: true });
+  });
+});
+
+// resolveEffectiveAgentId is exactly the binding resolution POST /api/requests
+// runs (reconcile + use-time liveness recheck), so testing it covers that route
+// branch including the revoked-binding case.
+describe("resolveEffectiveAgentId", () => {
+  it("passes the verified id through for an unbound (legacy) key", async () => {
+    expect(await resolveEffectiveAgentId(null, "agt_x")).toEqual({ agentId: "agt_x" });
+    expect(await resolveEffectiveAgentId(null, null)).toEqual({ agentId: null });
+  });
+
+  it("promotes an active binding (with or without a matching claim)", async () => {
+    const { agent } = await createAgent("ci");
+    expect(await resolveEffectiveAgentId(agent.id, null)).toEqual({ agentId: agent.id });
+    expect(await resolveEffectiveAgentId(agent.id, agent.id)).toEqual({ agentId: agent.id });
+  });
+
+  it("rejects a binding whose agent has been revoked (use-time recheck)", async () => {
+    const { agent } = await createAgent("ci");
+    await revokeAgent(agent.id);
+    expect(await resolveEffectiveAgentId(agent.id, null)).toEqual({ reject: "revoked_binding" });
+  });
+
+  it("rejects a binding to an unknown agent", async () => {
+    expect(await resolveEffectiveAgentId("agt_ghost", null)).toEqual({ reject: "revoked_binding" });
+  });
+
+  it("rejects a conflict before checking liveness", async () => {
+    const { agent } = await createAgent("ci");
+    expect(await resolveEffectiveAgentId(agent.id, "agt_other")).toEqual({ reject: "conflict" });
+  });
+});
+
+describe("POST /api/api-keys — virtual key issuance", () => {
+  it("issues a key bound to an active agent and echoes + persists agentId", async () => {
+    const { agent } = await createAgent("ci");
+    const res = await createKey({ name: "vk", scopes: ["admin"], agentId: agent.id });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.key).toMatch(/^agk_/);
+    expect(body.agentId).toBe(agent.id);
+    expect(persistedAgentId(body.id as string)).toBe(agent.id);
+  });
+
+  it("rejects binding to a nonexistent agent", async () => {
+    const res = await createKey({ name: "vk", scopes: ["admin"], agentId: "agt_nope" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects binding to a revoked agent", async () => {
+    const { agent } = await createAgent("ci");
+    await revokeAgent(agent.id);
+    const res = await createKey({ name: "vk", scopes: ["admin"], agentId: agent.id });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a malformed agentId (zod)", async () => {
+    const res = await createKey({ name: "vk", scopes: ["admin"], agentId: "not-an-agent" });
+    expect(res.status).toBe(400);
+  });
+
+  it("issues an unbound legacy key when agentId is omitted", async () => {
+    const res = await createKey({ name: "legacy", scopes: ["admin"] });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.agentId).toBeNull();
+    expect(persistedAgentId(body.id as string)).toBeNull();
+  });
+
+  it("surfaces agentId in the list endpoint", async () => {
+    const { agent } = await createAgent("ci");
+    const created = (await (await createKey({ name: "vk", scopes: ["admin"], agentId: agent.id })).json()) as {
+      id: string;
+    };
+    const listRes = await app().request("/api/api-keys");
+    expect(listRes.status).toBe(200);
+    const { keys } = (await listRes.json()) as { keys: Array<{ id: string; agentId: unknown }> };
+    expect(keys.find((k) => k.id === created.id)?.agentId).toBe(agent.id);
+  });
+});

--- a/packages/server/src/db/schema.postgres.ts
+++ b/packages/server/src/db/schema.postgres.ts
@@ -66,6 +66,7 @@ export const apiKeys = pgTable("api_keys", {
   lastUsedAt: integer("last_used_at"), // unix timestamp, nullable
   revokedAt: integer("revoked_at"), // unix timestamp, nullable
   rateLimit: integer("rate_limit"), // requests per minute, null = unlimited
+  agentId: text("agent_id"), // virtual key: agt_* this key is bound to; null = any agent (legacy)
 }, (table) => ({
   idxApiKeysHash: index("idx_api_keys_hash").on(table.keyHash),
 }));

--- a/packages/server/src/db/schema.sqlite.ts
+++ b/packages/server/src/db/schema.sqlite.ts
@@ -67,6 +67,7 @@ export const apiKeys = sqliteTable("api_keys", {
   lastUsedAt: integer("last_used_at"), // unix timestamp, nullable
   revokedAt: integer("revoked_at"), // unix timestamp, nullable
   rateLimit: integer("rate_limit"), // requests per minute, null = unlimited
+  agentId: text("agent_id"), // virtual key: agt_* this key is bound to; null = any agent (legacy)
 }, (table) => ({
   idxApiKeysHash: index("idx_api_keys_hash").on(table.keyHash),
 }));

--- a/packages/server/src/lib/agent-tokens.ts
+++ b/packages/server/src/lib/agent-tokens.ts
@@ -62,3 +62,40 @@ export async function resolveVerifiedAgentId(
   }
   return (await verifyAgentCredential(creds.agentId, creds.agentSecret))?.id ?? null;
 }
+
+/**
+ * Reconcile a virtual-key agent binding (issue #13) with the separately
+ * verified agent id. A key bound to an agent IS that agent's credential, so the
+ * binding is authoritative and promotes to the verified id. A DIFFERENT
+ * separately-verified agent on the same request is an unresolvable conflict.
+ * Returns { agentId } on success, or { conflict: true } when they disagree.
+ */
+export function reconcileBoundAgent(
+  boundAgentId: string | null,
+  verifiedAgentId: string | null,
+): { agentId: string | null } | { conflict: true } {
+  if (!boundAgentId) return { agentId: verifiedAgentId };
+  if (verifiedAgentId && verifiedAgentId !== boundAgentId) return { conflict: true };
+  return { agentId: boundAgentId };
+}
+
+/**
+ * Resolve the effective verified agent id for a request, accounting for a
+ * virtual-key binding (issue #13). The binding is authoritative, but the bound
+ * agent must still be ACTIVE at use time — mirroring the agent-token path,
+ * because revoking an agent does not cascade to keys bound to it. Returns the
+ * effective id, or a typed rejection the route maps to 403:
+ *   - "conflict":         the request separately verifies as a different agent
+ *   - "revoked_binding":  the key is bound to a revoked/unknown agent
+ */
+export async function resolveEffectiveAgentId(
+  boundAgentId: string | null,
+  verifiedAgentId: string | null,
+): Promise<{ agentId: string | null } | { reject: "conflict" | "revoked_binding" }> {
+  const reconciled = reconcileBoundAgent(boundAgentId, verifiedAgentId);
+  if ("conflict" in reconciled) return { reject: "conflict" };
+  if (boundAgentId && !(await getAgentIfActive(boundAgentId))) {
+    return { reject: "revoked_binding" };
+  }
+  return { agentId: reconciled.agentId };
+}

--- a/packages/server/src/lib/api-keys.ts
+++ b/packages/server/src/lib/api-keys.ts
@@ -117,12 +117,14 @@ export function generateApiKey(): { key: string; hash: string } {
  * @param name - Human-readable name for the key
  * @param scopes - Array of scopes like ["request:create", "request:read", "admin"]
  * @param rateLimit - Rate limit (requests per minute), null = unlimited
+ * @param agentId - Bind this key to an agent (agt_*); null = any agent (legacy)
  * @returns { id, key } - key is shown once to user
  */
 export async function createApiKey(
   name: string,
   scopes: string[],
-  rateLimit: number | null = null
+  rateLimit: number | null = null,
+  agentId: string | null = null
 ): Promise<{ id: string; key: string }> {
   const id = nanoid();
   const { key, hash } = generateApiKey();
@@ -134,6 +136,7 @@ export async function createApiKey(
     scopes: JSON.stringify(scopes),
     createdAt: Math.floor(Date.now() / 1000),
     rateLimit,
+    agentId,
   });
 
   return { id, key };

--- a/packages/server/src/routes/api-keys.ts
+++ b/packages/server/src/routes/api-keys.ts
@@ -5,6 +5,7 @@ import { eq } from 'drizzle-orm';
 import { getDb } from '../db/index.js';
 import { apiKeys } from '../db/schema.js';
 import { createApiKey, revokeApiKey } from '../lib/api-keys.js';
+import { getAgentIfActive } from '../lib/agents.js';
 import { requirePermission } from '../middleware/auth.js';
 
 const router = new Hono();
@@ -17,19 +18,29 @@ const createKeySchema = z.object({
   name: z.string().min(1).max(100),
   scopes: z.array(z.string()).min(1),
   rateLimit: z.number().int().positive().nullable().optional(),
+  // Virtual key (issue #13): bind this key to an agent. Omit for a legacy
+  // "any agent" key.
+  agentId: z.string().regex(/^agt_/, 'agentId must be an agt_ id').optional(),
 });
 
 router.post('/', zValidator('json', createKeySchema), async (c) => {
-  const { name, scopes, rateLimit } = c.req.valid('json');
-  const { id, key } = await createApiKey(name, scopes, rateLimit ?? null);
-  
+  const { name, scopes, rateLimit, agentId } = c.req.valid('json');
+
+  // Don't bind a key to a typo'd, nonexistent, or revoked agent.
+  if (agentId && !(await getAgentIfActive(agentId))) {
+    return c.json({ error: 'agentId does not match an active agent' }, 400);
+  }
+
+  const { id, key } = await createApiKey(name, scopes, rateLimit ?? null, agentId ?? null);
+
   // Return key ONCE - it won't be shown again
-  return c.json({ 
-    id, 
+  return c.json({
+    id,
     key,  // Only returned on creation!
-    name, 
+    name,
     scopes,
     rateLimit: rateLimit ?? null,
+    agentId: agentId ?? null,
     message: 'Save this key - it will not be shown again'
   }, 201);
 });
@@ -44,6 +55,7 @@ router.get('/', async (c) => {
     lastUsedAt: apiKeys.lastUsedAt,
     revokedAt: apiKeys.revokedAt,
     rateLimit: apiKeys.rateLimit,
+    agentId: apiKeys.agentId,
   }).from(apiKeys);
   
   return c.json({ 

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -16,14 +16,16 @@ import {
 } from "@agentgate/core";
 import { logAuditEvent } from "../lib/audit.js";
 import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
-import { resolveVerifiedAgentId } from "../lib/agent-tokens.js";
+import { resolveVerifiedAgentId, resolveEffectiveAgentId } from "../lib/agent-tokens.js";
 import { getConfig } from "../config.js";
+import type { ApiKey } from "../db/schema.js";
 import { deliverWebhook } from "../lib/webhook.js";
 import { getGlobalDispatcher } from "../lib/notification/index.js";
 import { getCachedPolicies } from "../lib/policy-cache.js";
 import { checkOverrides } from "./overrides.js";
 
-const requestsRouter = new Hono();
+// Variables: the auth middleware sets the validated apiKey row on api-key auth.
+const requestsRouter = new Hono<{ Variables: { apiKey?: ApiKey } }>();
 
 // Validation helper for creating requests
 function validateCreateRequestBody(body: unknown): {
@@ -267,6 +269,26 @@ requestsRouter.post("/", async (c) => {
     getConfig().authMode,
   );
 
+  // Virtual key (issue #13): a key bound to an agent IS that agent's credential,
+  // so the binding is authoritative and promotes to the verified id. A request
+  // that separately verifies as a DIFFERENT agent is a conflict, and a binding
+  // to a now-revoked agent is rejected — agent revocation does not cascade to
+  // keys, so the bound agent's liveness is re-checked here at use time.
+  const boundAgentId = c.get("apiKey")?.agentId ?? null;
+  const resolved = await resolveEffectiveAgentId(boundAgentId, verifiedAgentId);
+  if ("reject" in resolved) {
+    return c.json(
+      {
+        error:
+          resolved.reject === "conflict"
+            ? "API key is bound to a different agent than the request claims"
+            : "API key is bound to a revoked or unknown agent",
+      },
+      403,
+    );
+  }
+  const effectiveAgentId = resolved.agentId;
+
   // Insert into database
   await getDb().insert(approvalRequests).values({
     id,
@@ -281,7 +303,7 @@ requestsRouter.post("/", async (c) => {
     decidedBy,
     decisionReason,
     expiresAt,
-    verifiedAgentId,
+    verifiedAgentId: effectiveAgentId,
   });
 
   // Log audit event
@@ -297,7 +319,7 @@ requestsRouter.post("/", async (c) => {
     owaspRisk: owaspRiskForPolicyDecision(policyDecision.decision),
     // Who actually made the request, cryptographically verified (vs the
     // unverified context.agentId claim).
-    verifiedAgentId,
+    verifiedAgentId: effectiveAgentId,
   });
 
   // Emit request.created event


### PR DESCRIPTION
## Issue #13 — PR1: Virtual keys (agent-scoped API keys)

First slice of the "become a real gateway" epic, built on the merged agent-identity spine (#12). An admin binds an `agk_*` API key to a specific agent (`agt_*`); when a bound key authenticates `POST /api/requests`, that binding becomes the authoritative verified agent identity.

**Acceptance criterion #1** ("a virtual key created with `agentId=agent123` can only be used by requests claiming that agent ID") is satisfied.

### What's in
- **Schema** — `apiKeys.agentId` (nullable `text`, both dialects + generated migrations `0008`/`0005`, single `ALTER` each). `null` = legacy "any agent" key — **fully backward compatible**.
- **Issuance** — `POST /api/api-keys` accepts an optional `agentId`, validated against the agents registry (`getAgentIfActive`) before binding, and echoed in the create response + list projection. zod-guarded to `agt_*` ids.
- **Enforcement** (`routes/requests.ts`) — the bound agent **promotes** to `verifiedAgentId`; a request that separately verifies as a *different* agent → **403 conflict**; a binding to a *revoked/unknown* agent → **403** (use-time liveness recheck).
- **No hot-middleware change** — the validated key row already reaches the route via `c.get("apiKey")`.

### Enforcement model
```
boundAgentId | verifiedAgentId | result
   null       |   anything     | unchanged (legacy)
   agt_X      |   null          | effective = agt_X (binding alone proves identity)
   agt_X      |   agt_X         | effective = agt_X
   agt_X      |   agt_Y         | 403 conflict
   agt_X(revoked) | any         | 403 revoked binding
```
Logic lives in two helpers — pure `reconcileBoundAgent` + async `resolveEffectiveAgentId` (reconcile + liveness) — unit-tested directly, the exact shape the route runs.

### Reviewed
Ran a 24-agent adversarial review (enforcement/security, schema/migration/compat, issuance API, test quality). Its **fix-now** finding: the bound-key path was the only one of three credential paths *not* re-checking agent liveness at use time — `revokeAgent` doesn't cascade to keys, so a key bound to a revoked agent would have kept stamping that agent's id. **Fixed** by the use-time `getAgentIfActive` recheck → 403 (`revoked_binding`), with a regression test. Other findings were confirmations ("no fix needed") or low-severity follow-ups.

### Out of scope (follow-ups on #13)
Per-agent budgets / `agentSpend` (needs a cost/token-tracking backend that doesn't exist yet), per-agent policy scoping, PATCH re-binding, `keyType` column, dashboard UI.

### Tests
15 new (reconcile truth table; effective-agent resolution incl. revoked-binding + conflict + promote; issuance route incl. the active-agent gate, nonexistent/revoked/malformed rejection, and list projection). `agent_id` backported to the 7 hardcoded test `api_keys` schemas. `vitest run` → **640 passing**; the one failure is the env-dependent Redis-fallback test, unrelated. typecheck + eslint clean.

Closes part of #13.
