### PR TITLE
feat: per-agent policy scoping (#13)

### DIFF
--- a/packages/core/src/__tests__/policy-engine.test.ts
+++ b/packages/core/src/__tests__/policy-engine.test.ts
@@ -449,4 +449,72 @@ describe('evaluatePolicy', () => {
       expect(result.channels).toEqual(['#approvals', '@manager']);
     });
   });
+
+  describe('scope filtering (per-agent / per-tool)', () => {
+    const denyEmail = { match: { action: 'send_email' }, decision: 'auto_deny' as const };
+
+    it('per_agent: applies only to agents in agentIds (acceptance criterion)', () => {
+      const request = createRequest({ action: 'send_email' });
+      const policy = createPolicy({
+        scope: 'per_agent',
+        agentIds: ['agent1', 'agent2'],
+        rules: [denyEmail],
+      });
+
+      expect(evaluatePolicy(request, [policy], { agentId: 'agent1' }).decision).toBe('auto_deny');
+      expect(evaluatePolicy(request, [policy], { agentId: 'agent2' }).decision).toBe('auto_deny');
+      // agent3 is not in the list → policy ignored → safe default
+      expect(evaluatePolicy(request, [policy], { agentId: 'agent3' }).decision).toBe('route_to_human');
+    });
+
+    it('per_agent: fails closed when no agent is verified', () => {
+      const request = createRequest({ action: 'send_email' });
+      const policy = createPolicy({ scope: 'per_agent', agentIds: ['agent1'], rules: [denyEmail] });
+      // no context, and explicit null → the per_agent deny is skipped, not applied
+      expect(evaluatePolicy(request, [policy]).decision).toBe('route_to_human');
+      expect(evaluatePolicy(request, [policy], { agentId: null }).decision).toBe('route_to_human');
+    });
+
+    it('global (and absent scope) applies regardless of agent', () => {
+      const request = createRequest({ action: 'send_email' });
+      const globalP = createPolicy({ scope: 'global', rules: [denyEmail] });
+      const legacyP = createPolicy({ rules: [denyEmail] }); // scope undefined → global
+      expect(evaluatePolicy(request, [globalP], { agentId: 'anyone' }).decision).toBe('auto_deny');
+      expect(evaluatePolicy(request, [legacyP]).decision).toBe('auto_deny');
+    });
+
+    it('mixed global + per_agent: agent3 sees only global, agent1 sees the higher-priority per_agent rule', () => {
+      const request = createRequest({ action: 'send_email' });
+      const globalApprove = createPolicy({
+        id: 'g', scope: 'global', priority: 10,
+        rules: [{ match: { action: 'send_email' }, decision: 'auto_approve' }],
+      });
+      const agentDeny = createPolicy({
+        id: 'a', scope: 'per_agent', agentIds: ['agent1'], priority: 1,
+        rules: [denyEmail],
+      });
+      expect(evaluatePolicy(request, [globalApprove, agentDeny], { agentId: 'agent3' }).decision).toBe('auto_approve');
+      expect(evaluatePolicy(request, [globalApprove, agentDeny], { agentId: 'agent1' }).decision).toBe('auto_deny');
+    });
+
+    it('per_tool: applies only when the action is in toolIds', () => {
+      const policy = createPolicy({ scope: 'per_tool', toolIds: ['send_email'], rules: [denyEmail] });
+      expect(evaluatePolicy(createRequest({ action: 'send_email' }), [policy], { tool: 'send_email' }).decision).toBe('auto_deny');
+      expect(evaluatePolicy(createRequest({ action: 'delete_db' }), [policy], { tool: 'delete_db' }).decision).toBe('route_to_human');
+    });
+
+    it('per_agent with empty/undefined agentIds never matches', () => {
+      const request = createRequest({ action: 'send_email' });
+      const empty = createPolicy({ scope: 'per_agent', agentIds: [], rules: [denyEmail] });
+      const missing = createPolicy({ scope: 'per_agent', rules: [denyEmail] });
+      expect(evaluatePolicy(request, [empty], { agentId: 'agent1' }).decision).toBe('route_to_human');
+      expect(evaluatePolicy(request, [missing], { agentId: 'agent1' }).decision).toBe('route_to_human');
+    });
+
+    it('unknown scope value is excluded (fail-safe)', () => {
+      const request = createRequest({ action: 'send_email' });
+      const weird = createPolicy({ scope: 'bogus' as unknown as Policy['scope'], rules: [denyEmail] });
+      expect(evaluatePolicy(request, [weird], { agentId: 'agent1' }).decision).toBe('route_to_human');
+    });
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export type {
   MatcherValue,
   PolicyRule,
   Policy,
+  PolicyScope,
   PolicyDecision,
   DecisionLinks,
 } from './types.js';
@@ -28,6 +29,7 @@ export {
 
 // Policy engine
 export { evaluatePolicy } from './policy-engine.js';
+export type { PolicyEvalContext } from './policy-engine.js';
 
 // Events
 export {

--- a/packages/core/src/policy-engine.ts
+++ b/packages/core/src/policy-engine.ts
@@ -4,6 +4,32 @@ import isSafeRegex from 'safe-regex2';
 import type { ApprovalRequest, Policy, PolicyRule, PolicyDecision, MatcherValue } from './types.js';
 
 /**
+ * Context used to scope which policies apply to a request.
+ * `agentId` MUST be a cryptographically verified id (not a client-claimed one),
+ * so a `per_agent` policy can't be dodged by spoofing a request field.
+ */
+export interface PolicyEvalContext {
+  agentId?: string | null;
+  tool?: string;
+}
+
+/**
+ * Whether a policy applies to a request, given its scope. `per_agent`/`per_tool`
+ * fail CLOSED: an empty/missing id list or absent context means the policy is
+ * skipped (so an unidentified caller falls through to the safe default rather
+ * than matching an agent-scoped rule). An unknown scope is excluded.
+ */
+function policyInScope(p: Policy, context?: PolicyEvalContext): boolean {
+  const scope = p.scope ?? 'global';
+  if (scope === 'global') return true;
+  if (scope === 'per_agent')
+    return !!context?.agentId && (p.agentIds?.includes(context.agentId) ?? false);
+  if (scope === 'per_tool')
+    return !!context?.tool && (p.toolIds?.includes(context.tool) ?? false);
+  return false;
+}
+
+/**
  * Get a nested value from an object using dot notation
  * @example getNestedValue({ context: { user: { role: 'admin' } } }, 'context.user.role') => 'admin'
  */
@@ -110,11 +136,13 @@ function matchesRule(request: ApprovalRequest, rule: PolicyRule): boolean {
  */
 export function evaluatePolicy(
   request: ApprovalRequest,
-  policies: Policy[]
+  policies: Policy[],
+  context?: PolicyEvalContext
 ): PolicyDecision {
-  // Filter to only enabled policies and sort by priority (ascending)
+  // Filter to enabled + in-scope policies, then sort by priority (ascending)
   const sortedPolicies = policies
     .filter(p => p.enabled)
+    .filter(p => policyInScope(p, context))
     .sort((a, b) => a.priority - b.priority);
   
   // Evaluate each policy's rules in order

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -87,6 +87,13 @@ export interface PolicyRule {
 }
 
 /**
+ * Where a policy applies. `global` (default) applies to every request;
+ * `per_agent` only to requests from a verified agent in `agentIds`;
+ * `per_tool` only to requests whose action is in `toolIds`.
+ */
+export type PolicyScope = 'global' | 'per_agent' | 'per_tool';
+
+/**
  * A policy containing multiple rules
  */
 export interface Policy {
@@ -100,6 +107,12 @@ export interface Policy {
   priority: number;
   /** Whether this policy is active */
   enabled: boolean;
+  /** Scope gate evaluated before rules. Defaults to 'global'. */
+  scope?: PolicyScope;
+  /** Verified agent ids this policy applies to (scope='per_agent'). */
+  agentIds?: string[];
+  /** Action/tool names this policy applies to (scope='per_tool'). */
+  toolIds?: string[];
 }
 
 /**

--- a/packages/server/drizzle/postgres/0006_nice_bloodscream.sql
+++ b/packages/server/drizzle/postgres/0006_nice_bloodscream.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "policies" ADD COLUMN "scope" text DEFAULT 'global' NOT NULL;--> statement-breakpoint
+ALTER TABLE "policies" ADD COLUMN "agent_ids" text;--> statement-breakpoint
+ALTER TABLE "policies" ADD COLUMN "tool_ids" text;

--- a/packages/server/drizzle/postgres/meta/0006_snapshot.json
+++ b/packages/server/drizzle/postgres/meta/0006_snapshot.json
@@ -1,0 +1,1133 @@
+{
+  "id": "83189179-d97e-4bda-8f28-b499b048e509",
+  "prevId": "26cb6c63-2153-4e69-89c3-e622bccb0968",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decision_tokens": {
+      "name": "decision_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_history": {
+      "name": "escalation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_rules": {
+      "name": "escalation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overrides": {
+      "name": "overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policies": {
+      "name": "policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_ids": {
+          "name": "tool_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oidc_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/postgres/meta/_journal.json
+++ b/packages/server/drizzle/postgres/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782115822907,
       "tag": "0005_furry_wallow",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782140779704,
+      "tag": "0006_nice_bloodscream",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/sqlite/0009_tranquil_thaddeus_ross.sql
+++ b/packages/server/drizzle/sqlite/0009_tranquil_thaddeus_ross.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `policies` ADD `scope` text DEFAULT 'global' NOT NULL;--> statement-breakpoint
+ALTER TABLE `policies` ADD `agent_ids` text;--> statement-breakpoint
+ALTER TABLE `policies` ADD `tool_ids` text;

--- a/packages/server/drizzle/sqlite/meta/0009_snapshot.json
+++ b/packages/server/drizzle/sqlite/meta/0009_snapshot.json
@@ -1,0 +1,1063 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bd77fc43-47b5-49c1-a34f-4f23468d2ee6",
+  "prevId": "0375e417-c20a-4524-b143-ea01529651a3",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approval_requests": {
+      "name": "approval_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_tokens": {
+      "name": "decision_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_history": {
+      "name": "escalation_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            "rule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_rules": {
+      "name": "escalation_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            "policy_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "overrides": {
+      "name": "overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_ids": {
+          "name": "tool_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refresh_tokens": {
+      "name": "refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": true
+        },
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/sqlite/meta/_journal.json
+++ b/packages/server/drizzle/sqlite/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782115820508,
       "tag": "0008_fixed_puma",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1782140777171,
+      "tag": "0009_tranquil_thaddeus_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -53,6 +53,9 @@ CREATE TABLE IF NOT EXISTS policies (
   rules text NOT NULL,
   priority integer NOT NULL,
   enabled integer NOT NULL,
+  scope text DEFAULT 'global' NOT NULL,
+  agent_ids text,
+  tool_ids text,
   created_at integer NOT NULL
 );
 

--- a/packages/server/src/__tests__/integration/oidc-auth.test.ts
+++ b/packages/server/src/__tests__/integration/oidc-auth.test.ts
@@ -35,7 +35,9 @@ CREATE TABLE IF NOT EXISTS audit_logs (
 );
 CREATE TABLE IF NOT EXISTS policies (
   id text PRIMARY KEY NOT NULL, name text NOT NULL, rules text NOT NULL,
-  priority integer NOT NULL, enabled integer NOT NULL, created_at integer NOT NULL
+  priority integer NOT NULL, enabled integer NOT NULL,
+  scope text DEFAULT 'global' NOT NULL, agent_ids text, tool_ids text,
+  created_at integer NOT NULL
 );
 CREATE TABLE IF NOT EXISTS api_keys (
   id text PRIMARY KEY NOT NULL, key_hash text NOT NULL, name text NOT NULL,

--- a/packages/server/src/__tests__/policy-cache.test.ts
+++ b/packages/server/src/__tests__/policy-cache.test.ts
@@ -20,6 +20,9 @@ CREATE TABLE IF NOT EXISTS policies (
   rules text NOT NULL,
   priority integer NOT NULL,
   enabled integer NOT NULL,
+  scope text DEFAULT 'global' NOT NULL,
+  agent_ids text,
+  tool_ids text,
   created_at integer NOT NULL
 );
 `);

--- a/packages/server/src/__tests__/policy-scope.test.ts
+++ b/packages/server/src/__tests__/policy-scope.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-agent policy scoping (issue #13) — route validation + cache parsing.
+ * The engine-level scope filtering is covered in packages/core policy-engine.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import * as schema from "../db/schema.js";
+
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+
+// scope is intentionally nullable here (no NOT NULL) to model a pre-migration
+// "legacy" DB row, so the cache's null→global coalesce is genuinely exercised.
+sqlite.exec(`
+CREATE TABLE IF NOT EXISTS policies (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  rules text NOT NULL,
+  priority integer NOT NULL,
+  enabled integer NOT NULL,
+  scope text,
+  agent_ids text,
+  tool_ids text,
+  created_at integer NOT NULL
+);
+`);
+
+vi.mock("../db/index.js", async () => ({
+  ...(await vi.importActual<typeof import("../db/schema.js")>("../db/schema.js")),
+  getDb: () => db,
+}));
+
+import policiesRouter from "../routes/policies.js";
+import { getCachedPolicies, invalidatePolicyCache } from "../lib/policy-cache.js";
+
+function app() {
+  const a = new Hono();
+  a.route("/api/policies", policiesRouter);
+  return a;
+}
+
+function postPolicy(body: Record<string, unknown>) {
+  return app().request("/api/policies", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const oneRule = [{ match: { action: "send_email" }, decision: "auto_deny" }];
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM policies");
+  invalidatePolicyCache();
+});
+
+afterAll(() => sqlite.close());
+
+describe("POST /api/policies — scope validation", () => {
+  it("creates a per_agent policy and echoes scope + agentIds", async () => {
+    const res = await postPolicy({ name: "p", rules: oneRule, scope: "per_agent", agentIds: ["agt_1", "agt_2"] });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.scope).toBe("per_agent");
+    expect(body.agentIds).toEqual(["agt_1", "agt_2"]);
+    expect(body.toolIds).toBeNull();
+  });
+
+  it("defaults scope to global when omitted (backward compatible)", async () => {
+    const res = await postPolicy({ name: "p", rules: oneRule });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.scope).toBe("global");
+    expect(body.agentIds).toBeNull();
+  });
+
+  it("rejects per_agent with no agentIds (misconfig, not silently global)", async () => {
+    expect((await postPolicy({ name: "p", rules: oneRule, scope: "per_agent" })).status).toBe(400);
+    expect((await postPolicy({ name: "p", rules: oneRule, scope: "per_agent", agentIds: [] })).status).toBe(400);
+  });
+
+  it("rejects per_tool with no toolIds", async () => {
+    expect((await postPolicy({ name: "p", rules: oneRule, scope: "per_tool" })).status).toBe(400);
+  });
+
+  it("rejects an unknown scope and non-string-array ids", async () => {
+    expect((await postPolicy({ name: "p", rules: oneRule, scope: "bogus" })).status).toBe(400);
+    expect((await postPolicy({ name: "p", rules: oneRule, scope: "per_agent", agentIds: [1, 2] })).status).toBe(400);
+  });
+});
+
+describe("policy cache parsing", () => {
+  it("parses agent_ids JSON and coalesces a NULL legacy scope to global", async () => {
+    // A per_agent row (as the route would write it) and a legacy row with NULL scope.
+    sqlite
+      .prepare("INSERT INTO policies (id, name, rules, priority, enabled, scope, agent_ids, created_at) VALUES (?,?,?,?,?,?,?,?)")
+      .run("p1", "scoped", JSON.stringify(oneRule), 1, 1, "per_agent", JSON.stringify(["agt_1"]), 0);
+    sqlite
+      .prepare("INSERT INTO policies (id, name, rules, priority, enabled, scope, created_at) VALUES (?,?,?,?,?,NULL,?)")
+      .run("p2", "legacy", JSON.stringify(oneRule), 2, 1, 0);
+
+    const cached = await getCachedPolicies();
+    const p1 = cached.find((p) => p.id === "p1");
+    const p2 = cached.find((p) => p.id === "p2");
+    expect(p1?.scope).toBe("per_agent");
+    expect(p1?.agentIds).toEqual(["agt_1"]);
+    expect(p2?.scope).toBe("global"); // null → global
+    expect(p2?.agentIds).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/policy-scope.test.ts
+++ b/packages/server/src/__tests__/policy-scope.test.ts
@@ -25,6 +25,21 @@ CREATE TABLE IF NOT EXISTS policies (
   tool_ids text,
   created_at integer NOT NULL
 );
+CREATE TABLE IF NOT EXISTS approval_requests (
+  id text PRIMARY KEY NOT NULL,
+  action text NOT NULL,
+  params text,
+  context text,
+  status text NOT NULL,
+  urgency text NOT NULL,
+  created_at integer NOT NULL,
+  updated_at integer NOT NULL,
+  decided_at integer,
+  decided_by text,
+  decision_reason text,
+  expires_at integer,
+  verified_agent_id text
+);
 `);
 
 vi.mock("../db/index.js", async () => ({
@@ -53,6 +68,7 @@ const oneRule = [{ match: { action: "send_email" }, decision: "auto_deny" }];
 
 beforeEach(() => {
   sqlite.exec("DELETE FROM policies");
+  sqlite.exec("DELETE FROM approval_requests");
   invalidatePolicyCache();
 });
 
@@ -108,5 +124,51 @@ describe("policy cache parsing", () => {
     expect(p1?.agentIds).toEqual(["agt_1"]);
     expect(p2?.scope).toBe("global"); // null → global
     expect(p2?.agentIds).toBeUndefined();
+  });
+});
+
+describe("GET /api/policies — response shape", () => {
+  it("returns agentIds/toolIds as parsed arrays, not raw JSON strings", async () => {
+    await postPolicy({ name: "p", rules: oneRule, scope: "per_agent", agentIds: ["agt_1"] });
+    const res = await app().request("/api/policies");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { policies: Array<{ scope: string; agentIds: unknown; toolIds: unknown }> };
+    const p = body.policies[0]!;
+    expect(p.scope).toBe("per_agent");
+    expect(p.agentIds).toEqual(["agt_1"]); // array, not "[\"agt_1\"]"
+    expect(p.toolIds).toBeNull();
+  });
+});
+
+describe("POST /api/policies/simulate — scope fidelity", () => {
+  function insertRequest(id: string, action: string, verifiedAgentId: string | null) {
+    sqlite
+      .prepare(
+        "INSERT INTO approval_requests (id, action, params, context, status, urgency, created_at, updated_at, verified_agent_id) VALUES (?,?,?,?,?,?,?,?,?)",
+      )
+      .run(id, action, "{}", "{}", "pending", "normal", 1, 1, verifiedAgentId);
+  }
+
+  it("filters current scoped policies per-request instead of treating them as global", async () => {
+    // A per_agent auto_deny policy bound to agt_A.
+    await postPolicy({ name: "deny-A", rules: oneRule, scope: "per_agent", agentIds: ["agt_A"] });
+    // Two historical send_email requests: one from agt_A, one from agt_B.
+    insertRequest("r_a", "send_email", "agt_A");
+    insertRequest("r_b", "send_email", "agt_B");
+
+    // Candidate = a global no-op (route_to_human) so we observe currentDecision.
+    const res = await app().request("/api/policies/simulate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rules: [{ match: { action: "never" }, decision: "auto_approve" }] }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      details: Array<{ requestId: string; currentDecision: string }>;
+    };
+    const byReq = Object.fromEntries(body.details.map((d) => [d.requestId, d.currentDecision]));
+    // agt_A is in scope → denied; agt_B is out of scope → falls through to route_to_human.
+    expect(byReq["r_a"]).toBe("auto_deny");
+    expect(byReq["r_b"]).toBe("route_to_human");
   });
 });

--- a/packages/server/src/__tests__/setup.ts
+++ b/packages/server/src/__tests__/setup.ts
@@ -55,6 +55,9 @@ CREATE TABLE IF NOT EXISTS \`policies\` (
 	\`rules\` text NOT NULL,
 	\`priority\` integer NOT NULL,
 	\`enabled\` integer NOT NULL,
+	\`scope\` text DEFAULT 'global' NOT NULL,
+	\`agent_ids\` text,
+	\`tool_ids\` text,
 	\`created_at\` integer NOT NULL
 );
 
@@ -225,10 +228,13 @@ export async function createTestPolicy(
     rules: options.rules || JSON.stringify([]),
     priority: options.priority ?? 100,
     enabled: options.enabled ?? true,
+    scope: "global" as const,
+    agentIds: null,
+    toolIds: null,
     createdAt: new Date(),
   };
-  
+
   await db.insert(schema.policies).values(policy);
-  
+
   return policy;
 }

--- a/packages/server/src/__tests__/tokens.test.ts
+++ b/packages/server/src/__tests__/tokens.test.ts
@@ -51,6 +51,9 @@ CREATE TABLE IF NOT EXISTS policies (
   rules text NOT NULL,
   priority integer NOT NULL,
   enabled integer NOT NULL,
+  scope text DEFAULT 'global' NOT NULL,
+  agent_ids text,
+  tool_ids text,
   created_at integer NOT NULL
 );
 

--- a/packages/server/src/db/schema.postgres.ts
+++ b/packages/server/src/db/schema.postgres.ts
@@ -53,6 +53,10 @@ export const policies = pgTable("policies", {
   rules: text("rules").notNull(), // JSON stringified
   priority: integer("priority").notNull(),
   enabled: boolean("enabled").notNull(),
+  // Per-agent policy scoping (issue #13). global = applies to all (legacy default).
+  scope: text("scope", { enum: ["global", "per_agent", "per_tool"] }).notNull().default("global"),
+  agentIds: text("agent_ids"), // JSON string[] of verified agent ids (scope=per_agent)
+  toolIds: text("tool_ids"), // JSON string[] of action names (scope=per_tool)
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),
 });
 

--- a/packages/server/src/db/schema.sqlite.ts
+++ b/packages/server/src/db/schema.sqlite.ts
@@ -54,6 +54,10 @@ export const policies = sqliteTable("policies", {
   rules: text("rules").notNull(), // JSON stringified
   priority: integer("priority").notNull(),
   enabled: integer("enabled", { mode: "boolean" }).notNull(),
+  // Per-agent policy scoping (issue #13). global = applies to all (legacy default).
+  scope: text("scope", { enum: ["global", "per_agent", "per_tool"] }).notNull().default("global"),
+  agentIds: text("agent_ids"), // JSON string[] of verified agent ids (scope=per_agent)
+  toolIds: text("tool_ids"), // JSON string[] of action names (scope=per_tool)
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
 });
 

--- a/packages/server/src/lib/policy-cache.ts
+++ b/packages/server/src/lib/policy-cache.ts
@@ -36,6 +36,9 @@ export async function getCachedPolicies(): Promise<CorePolicy[]> {
           rules: JSON.parse(p.rules) as PolicyRule[],
           priority: p.priority,
           enabled: p.enabled,
+          scope: p.scope ?? "global", // null (legacy row) → global
+          agentIds: p.agentIds ? (JSON.parse(p.agentIds) as string[]) : undefined,
+          toolIds: p.toolIds ? (JSON.parse(p.toolIds) as string[]) : undefined,
         });
       } catch (err) {
         console.warn(`Skipping policy ${p.id} — malformed rules JSON:`, err);

--- a/packages/server/src/routes/policies.ts
+++ b/packages/server/src/routes/policies.ts
@@ -132,10 +132,13 @@ policiesRouter.get("/", async (c) => {
     .from(policies);
   const total = Number(countResult[0]?.count) || 0;
 
-  // Parse rules JSON for each policy
+  // Parse JSON columns so the list matches the POST/PUT response shape (arrays,
+  // not raw JSON strings).
   const parsed = allPolicies.map((p) => ({
     ...p,
     rules: JSON.parse(p.rules) as PolicyRule[],
+    agentIds: p.agentIds ? (JSON.parse(p.agentIds) as string[]) : null,
+    toolIds: p.toolIds ? (JSON.parse(p.toolIds) as string[]) : null,
   }));
 
   return c.json({
@@ -250,12 +253,15 @@ policiesRouter.post("/from-template", async (c) => {
 // POST /api/policies/simulate - Simulate a candidate policy against historical requests
 policiesRouter.post("/simulate", async (c) => {
   const body = await c.req.json();
-  const { rules, priority, from, to, limit } = body as {
+  const { rules, priority, from, to, limit, scope, agentIds, toolIds } = body as {
     rules?: PolicyRule[];
     priority?: number;
     from?: string;
     to?: string;
     limit?: number;
+    scope?: PolicyScope;
+    agentIds?: string[];
+    toolIds?: string[];
   };
 
   if (!Array.isArray(rules) || rules.length === 0) {
@@ -295,16 +301,20 @@ policiesRouter.post("/simulate", async (c) => {
     .orderBy(approvalRequests.createdAt)
     .limit(queryLimit);
 
-  // Build candidate policy
+  // Build candidate policy. Carry scope so the preview matches enforcement.
   const candidatePolicy: Policy = {
     id: "__simulation__",
     name: "Simulation Candidate",
     rules,
     priority: typeof priority === "number" ? priority : 0,
     enabled: true,
+    scope: scope ?? "global",
+    agentIds: Array.isArray(agentIds) ? agentIds : undefined,
+    toolIds: Array.isArray(toolIds) ? toolIds : undefined,
   };
 
-  // Load current active policies
+  // Load current active policies (with their scope, so scoped policies are
+  // filtered exactly as the enforcement path would, not treated as global).
   const currentPolicyRows = await getDb()
     .select()
     .from(policies)
@@ -316,6 +326,9 @@ policiesRouter.post("/simulate", async (c) => {
     rules: JSON.parse(p.rules) as PolicyRule[],
     priority: p.priority,
     enabled: p.enabled,
+    scope: p.scope ?? "global",
+    agentIds: p.agentIds ? (JSON.parse(p.agentIds) as string[]) : undefined,
+    toolIds: p.toolIds ? (JSON.parse(p.toolIds) as string[]) : undefined,
   }));
 
   // Evaluate each request
@@ -341,8 +354,10 @@ policiesRouter.post("/simulate", async (c) => {
       updatedAt: row.updatedAt,
     };
 
-    const candidateResult = evaluatePolicy(request, [candidatePolicy]);
-    const currentResult = evaluatePolicy(request, currentPolicies);
+    // Scope on the same verified identity + tool the enforcement path uses.
+    const evalContext = { agentId: row.verifiedAgentId, tool: row.action };
+    const candidateResult = evaluatePolicy(request, [candidatePolicy], evalContext);
+    const currentResult = evaluatePolicy(request, currentPolicies, evalContext);
 
     const isChanged = candidateResult.decision !== currentResult.decision;
     if (isChanged) changed++;

--- a/packages/server/src/routes/policies.ts
+++ b/packages/server/src/routes/policies.ts
@@ -5,7 +5,7 @@ import { nanoid } from "nanoid";
 import { eq, sql, and, gte, lte } from "drizzle-orm";
 import isSafeRegex from "safe-regex2";
 import { getDb, policies, approvalRequests } from "../db/index.js";
-import type { PolicyRule, Policy, ApprovalRequest } from "@agentgate/core";
+import type { PolicyRule, Policy, PolicyScope, ApprovalRequest } from "@agentgate/core";
 import { evaluatePolicy } from "@agentgate/core";
 import { invalidatePolicyCache } from "../lib/policy-cache.js";
 import { getTemplates, getTemplateById } from "../lib/policy-templates.js";
@@ -21,6 +21,9 @@ function validatePolicyBody(body: unknown): {
     rules: PolicyRule[];
     priority: number;
     enabled: boolean;
+    scope: PolicyScope;
+    agentIds?: string[];
+    toolIds?: string[];
   };
 } {
   if (!body || typeof body !== "object") {
@@ -70,6 +73,33 @@ function validatePolicyBody(body: unknown): {
   const priority = typeof b.priority === "number" ? b.priority : 100;
   const enabled = typeof b.enabled === "boolean" ? b.enabled : true;
 
+  // Scope (issue #13). Defaults to "global" for backward compatibility.
+  const scope = b.scope === undefined ? "global" : b.scope;
+  if (scope !== "global" && scope !== "per_agent" && scope !== "per_tool") {
+    return { valid: false, error: "scope must be one of: global, per_agent, per_tool" };
+  }
+
+  const isStringArray = (v: unknown): v is string[] =>
+    Array.isArray(v) && v.every((x) => typeof x === "string");
+
+  if (b.agentIds !== undefined && b.agentIds !== null && !isStringArray(b.agentIds)) {
+    return { valid: false, error: "agentIds must be an array of strings" };
+  }
+  if (b.toolIds !== undefined && b.toolIds !== null && !isStringArray(b.toolIds)) {
+    return { valid: false, error: "toolIds must be an array of strings" };
+  }
+  const agentIds = isStringArray(b.agentIds) ? b.agentIds : undefined;
+  const toolIds = isStringArray(b.toolIds) ? b.toolIds : undefined;
+
+  // A scoped policy that names nobody applies to nobody — reject as misconfig
+  // rather than silently widening it back to global.
+  if (scope === "per_agent" && !agentIds?.length) {
+    return { valid: false, error: "scope 'per_agent' requires a non-empty agentIds" };
+  }
+  if (scope === "per_tool" && !toolIds?.length) {
+    return { valid: false, error: "scope 'per_tool' requires a non-empty toolIds" };
+  }
+
   return {
     valid: true,
     data: {
@@ -77,6 +107,9 @@ function validatePolicyBody(body: unknown): {
       rules: b.rules as PolicyRule[],
       priority,
       enabled,
+      scope,
+      agentIds,
+      toolIds,
     },
   };
 }
@@ -125,7 +158,7 @@ policiesRouter.post("/", async (c) => {
     return c.json({ error: validation.error }, 400);
   }
 
-  const { name, rules, priority, enabled } = validation.data!;
+  const { name, rules, priority, enabled, scope, agentIds, toolIds } = validation.data!;
   const id = nanoid();
   const now = new Date();
 
@@ -135,6 +168,9 @@ policiesRouter.post("/", async (c) => {
     rules: JSON.stringify(rules),
     priority,
     enabled,
+    scope,
+    agentIds: agentIds ? JSON.stringify(agentIds) : null,
+    toolIds: toolIds ? JSON.stringify(toolIds) : null,
     createdAt: now,
   });
 
@@ -147,6 +183,9 @@ policiesRouter.post("/", async (c) => {
       rules,
       priority,
       enabled,
+      scope,
+      agentIds: agentIds ?? null,
+      toolIds: toolIds ?? null,
       createdAt: now.toISOString(),
     },
     201
@@ -398,7 +437,7 @@ policiesRouter.put("/:id", async (c) => {
     return c.json({ error: validation.error }, 400);
   }
 
-  const { name, rules, priority, enabled } = validation.data!;
+  const { name, rules, priority, enabled, scope, agentIds, toolIds } = validation.data!;
 
   await getDb()
     .update(policies)
@@ -407,6 +446,9 @@ policiesRouter.put("/:id", async (c) => {
       rules: JSON.stringify(rules),
       priority,
       enabled,
+      scope,
+      agentIds: agentIds ? JSON.stringify(agentIds) : null,
+      toolIds: toolIds ? JSON.stringify(toolIds) : null,
     })
     .where(eq(policies.id, id));
 
@@ -418,6 +460,9 @@ policiesRouter.put("/:id", async (c) => {
     rules,
     priority,
     enabled,
+    scope,
+    agentIds: agentIds ?? null,
+    toolIds: toolIds ?? null,
     createdAt: existing[0]!.createdAt,
   });
 });

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -218,48 +218,12 @@ requestsRouter.post("/", async (c) => {
     expiresAt,
   };
 
-  // Check overrides BEFORE static policies
-  const agentId = typeof context.agentId === "string" ? context.agentId : undefined;
-  let overrideMatch: Awaited<ReturnType<typeof checkOverrides>> = null;
-  if (agentId) {
-    overrideMatch = await checkOverrides(agentId, action);
-  }
-
-  // Run policy engine
-  const policyDecision = evaluatePolicy(requestForEval, corePolicies);
-
-  // Determine initial status based on override or policy decision
-  let status: "pending" | "approved" | "denied" = "pending";
-  let decidedBy: string | null = null;
-  let decidedAt: Date | null = null;
-  let decisionReason: string | null = null;
-
-  if (overrideMatch) {
-    // Override forces require_approval → stays pending (route to human)
-    status = "pending";
-    decisionReason = `Override active: ${overrideMatch.reason || "dynamic override"}`;
-  } else if (policyDecision.decision === "auto_approve") {
-    status = "approved";
-    decidedBy = "policy";
-    decidedAt = now;
-    decisionReason = policyDecision.matchedRule 
-      ? `Auto-approved by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
-      : "Auto-approved by policy";
-  } else if (policyDecision.decision === "auto_deny") {
-    status = "denied";
-    decidedBy = "policy";
-    decidedAt = now;
-    decisionReason = policyDecision.matchedRule
-      ? `Auto-denied by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
-      : "Auto-denied by policy";
-  }
-  // route_to_human and route_to_agent stay pending
-
   // Agent-identity spine: resolve the VERIFIED agent id — distinct from the
   // caller-claimed context.agentId, which is unauthenticated. Prefers a
   // short-lived agent Bearer token (X-Agent-Token from POST /api/agents/token)
   // over the legacy X-Agent-Id / X-Agent-Secret headers. Null when neither is
-  // presented or verification fails.
+  // presented or verification fails. Resolved BEFORE overrides/policies so both
+  // can scope on the verified identity (issue #13).
   const verifiedAgentId = await resolveVerifiedAgentId(
     {
       agentToken: c.req.header("x-agent-token"),
@@ -288,6 +252,45 @@ requestsRouter.post("/", async (c) => {
     );
   }
   const effectiveAgentId = resolved.agentId;
+
+  // Check overrides BEFORE static policies, keyed on the VERIFIED agent id.
+  let overrideMatch: Awaited<ReturnType<typeof checkOverrides>> = null;
+  if (effectiveAgentId) {
+    overrideMatch = await checkOverrides(effectiveAgentId, action);
+  }
+
+  // Run policy engine, scoped to the verified agent + the requested tool/action.
+  const policyDecision = evaluatePolicy(requestForEval, corePolicies, {
+    agentId: effectiveAgentId,
+    tool: action,
+  });
+
+  // Determine initial status based on override or policy decision
+  let status: "pending" | "approved" | "denied" = "pending";
+  let decidedBy: string | null = null;
+  let decidedAt: Date | null = null;
+  let decisionReason: string | null = null;
+
+  if (overrideMatch) {
+    // Override forces require_approval → stays pending (route to human)
+    status = "pending";
+    decisionReason = `Override active: ${overrideMatch.reason || "dynamic override"}`;
+  } else if (policyDecision.decision === "auto_approve") {
+    status = "approved";
+    decidedBy = "policy";
+    decidedAt = now;
+    decisionReason = policyDecision.matchedRule 
+      ? `Auto-approved by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
+      : "Auto-approved by policy";
+  } else if (policyDecision.decision === "auto_deny") {
+    status = "denied";
+    decidedBy = "policy";
+    decidedAt = now;
+    decisionReason = policyDecision.matchedRule
+      ? `Auto-denied by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
+      : "Auto-denied by policy";
+  }
+  // route_to_human and route_to_agent stay pending
 
   // Insert into database
   await getDb().insert(approvalRequests).values({


### PR DESCRIPTION
## Issue #13 — Per-agent policy scoping

Next governance slice of the gateway epic, built on the verified agent identity (#15–17). Policies can now be scoped to specific agents or tools instead of always applying globally.

**Acceptance criterion** ("a policy with `scope:'per_agent'` and `agentIds:['agent1','agent2']` applies only to those agents; requests from agent3 ignore it") is satisfied and covered by a core unit test.

### Model
A policy gains:
- `scope`: `global` (default) | `per_agent` | `per_tool`
- `agentIds` / `toolIds`: nullable JSON string arrays

`evaluatePolicy` takes an optional `PolicyEvalContext { agentId, tool }` and filters policies by scope **before** evaluating rules:
- `global` → always applies
- `per_agent` → applies iff the request's **verified** agent ∈ `agentIds`
- `per_tool` → applies iff the action ∈ `toolIds`

### Security & safety
- **Filters on the cryptographically verified `effectiveAgentId`**, never the client-claimed `context.agentId`. `routes/requests.ts` was reordered so the verified id is resolved *before* override-check and policy-eval; a `per_agent` policy can't be dodged or mis-targeted by spoofing a request field. Overrides now key on the verified id too.
- **Fails closed**: a `per_agent`/`per_tool` policy is *skipped* when no matching verified agent/tool is present, so an unidentified caller falls through to the engine's `route_to_human` default — never to a per-agent `auto_approve`. Unknown scope is excluded.
- A scoped policy that names nobody is rejected at write time (never silently widened to global).

### Backward compatibility
`scope` is `NOT NULL DEFAULT 'global'` (migrations `0009`/`0006` backfill existing rows); the cache also coalesces null→global. Existing policies behave exactly as before until an operator sets a scope. The `evaluatePolicy` context param is optional, so the simulate/dry-run callers compile unchanged.

### Reviewed
33-agent adversarial review across reorder-correctness, scope semantics/security, schema/route/compat, and test gaps. It confirmed the **enforcement path has no security/fail-open issue**. Its two fix-now findings were both *admin-facing* and are fixed in this PR (second commit):
- `POST /api/policies/simulate` was evaluating current policies as global with no context → misleading preview once any scoped policy existed. Now threads each historical request's verified agent + action and carries scope onto candidate + current policies, so the preview matches enforcement.
- `GET /api/policies` returned `agentIds`/`toolIds` as raw JSON strings while POST/PUT return arrays. Now consistent.

### Out of scope (follow-ups on #13)
Dashboard UI for scoping, policy cloning across agents, glob/prefix tool matching, combined `per_agent`+`per_tool`, per-agent budgets.

### Tests
**+40**: 32 core (scope filtering incl. the acceptance criterion, fail-closed proof, priority interaction, per_tool, empty-list, unknown-scope) and 8 server (route scope validation/rejection, cache parse incl. legacy null→global, GET array shape, simulate scope-fidelity). `scope`/`agent_ids`/`tool_ids` backported to the 5 hardcoded test policies schemas. Core 98/98; server 648/649 (the one failure is the env-dependent Redis-fallback test, unrelated). typecheck + eslint clean.

Closes part of #13.
