### PR TITLE
feat: MCP tool-call guardrails (#14)

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,7 +9,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiConfig } from './types.js';
-import { toolDefinitions, handleToolCall } from './tools.js';
+import { toolDefinitions, handleToolCall, authorizeTool, formatResult } from './tools.js';
 
 const config: ApiConfig = {
   baseUrl: process.env.AGENTGATE_URL ?? 'http://localhost:3000',
@@ -26,9 +26,19 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [...toolDefinitions],
 }));
 
-// Handle tool calls
+// Handle tool calls — gate on per-agent guardrails (issue #14) before executing.
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
+  const verdict = await authorizeTool(config, name, args ?? {});
+  if (verdict?.decision === 'requires_approval') {
+    // Tool does NOT run; it is escalated to the approval flow.
+    return formatResult({
+      status: 'pending',
+      requestId: verdict.requestId,
+      reason: verdict.reason ?? null,
+      message: 'Tool call requires approval and was routed to AgentGate.',
+    });
+  }
   return handleToolCall(config, name, args ?? {});
 });
 

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -5,6 +5,7 @@ import {
   formatResult,
   formatError,
   handleToolCall,
+  authorizeTool,
   toolDefinitions,
   normalizeDecidedBy,
 } from './tools.js';
@@ -505,5 +506,46 @@ describe('handleToolCall', () => {
     );
     expect(result.isError).toBeUndefined();
     expect(JSON.parse(result.content[0]!.text)).toEqual(responseData);
+  });
+});
+
+describe('authorizeTool (MCP guardrail, #14)', () => {
+  const config: ApiConfig = { baseUrl: 'http://localhost:3000', apiKey: 'test-key' };
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('POSTs the tool name to /api/mcp/authorize and returns the verdict', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ decision: 'allow' }),
+    });
+    const verdict = await authorizeTool(config, 'file.read', { path: '/tmp' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/api/mcp/authorize',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const sentBody = JSON.parse((fetchMock.mock.calls[0]![1] as { body: string }).body);
+    expect(sentBody).toEqual({ toolName: 'file.read', params: { path: '/tmp' } });
+    expect(verdict).toEqual({ decision: 'allow' });
+  });
+
+  it('passes through a requires_approval verdict', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ decision: 'requires_approval', status: 'pending', requestId: 'req-9' }),
+    });
+    const verdict = await authorizeTool(config, 'send_email', {});
+    expect(verdict?.decision).toBe('requires_approval');
+    expect(verdict?.requestId).toBe('req-9');
+  });
+
+  it('fails OPEN (returns null) on a network/auth error', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('') });
+    expect(await authorizeTool(config, 'file.read', {})).toBeNull();
   });
 });

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -374,6 +374,30 @@ export async function handleGetAuditActors(
 }
 
 /**
+ * Ask the server whether a tool call is allowed for this MCP server's identity
+ * (issue #14). The server keys the guardrail on the verified agent bound to the
+ * api key. Returns the verdict, or null to fail-open (allow) on a network/auth
+ * error — the gate only ever escalates to a human, never hard-denies.
+ * ponytail: fail-open on error; add an AGENTGATE_GUARDRAIL_STRICT flag if a
+ * deployment needs the gate to fail closed.
+ */
+export async function authorizeTool(
+  config: ApiConfig,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<{ decision: string; status?: string; requestId?: string; reason?: string | null } | null> {
+  try {
+    return (await apiCall(config, "POST", "/api/mcp/authorize", {
+      toolName,
+      params: args,
+    })) as { decision: string; status?: string; requestId?: string; reason?: string | null };
+  } catch (err) {
+    console.error(`[guardrail] authorize failed for ${toolName}, allowing:`, err);
+    return null;
+  }
+}
+
+/**
  * Route tool call to appropriate handler
  */
 export async function handleToolCall(

--- a/packages/server/src/__tests__/mcp-guardrails.test.ts
+++ b/packages/server/src/__tests__/mcp-guardrails.test.ts
@@ -41,6 +41,7 @@ vi.mock("../db/index.js", async () => ({
 import { createAgent } from "../lib/agents.js";
 import mcpRouter from "../routes/mcp.js";
 import { parseConfig, setConfig, resetConfig } from "../config.js";
+import { getGlobalEmitter, EventNames } from "@agentgate/core";
 
 const TEST_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
 
@@ -123,6 +124,25 @@ describe("POST /api/mcp/authorize", () => {
 
     expect(((await (await authorize("file.read")).json()) as { decision: string }).decision).toBe("requires_approval");
     expect(((await (await authorize("file.write")).json()) as { decision: string }).decision).toBe("allow");
+  });
+
+  it("emits a request.created event so the gated call notifies approvers", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    boundAgentId = agent.id;
+    addOverride(agent.id, "*");
+
+    const events: Array<{ type: string; payload: { requestId?: string; action?: string } }> = [];
+    const off = getGlobalEmitter().on(EventNames.REQUEST_CREATED, (e) => {
+      events.push(e as (typeof events)[number]);
+    });
+    try {
+      const body = (await (await authorize("send_email", { to: "x@y.io" })).json()) as { requestId: string };
+      const ev = events.find((e) => e.payload.requestId === body.requestId);
+      expect(ev).toBeDefined();
+      expect(ev!.payload.action).toBe("send_email");
+    } finally {
+      off();
+    }
   });
 
   it("tags the audit trail with OWASP LLM06 (acceptance c)", async () => {

--- a/packages/server/src/__tests__/mcp-guardrails.test.ts
+++ b/packages/server/src/__tests__/mcp-guardrails.test.ts
@@ -1,0 +1,171 @@
+/**
+ * MCP tool-call guardrails (issue #14) — POST /api/mcp/authorize + evaluation.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import { nanoid } from "nanoid";
+import * as schema from "../db/schema.js";
+
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+
+sqlite.exec(`
+CREATE TABLE IF NOT EXISTS agents (
+  id text PRIMARY KEY NOT NULL, name text NOT NULL, secret_hash text NOT NULL,
+  status text NOT NULL, metadata text, created_at integer NOT NULL,
+  last_seen_at integer, revoked_at integer
+);
+CREATE TABLE IF NOT EXISTS overrides (
+  id text PRIMARY KEY NOT NULL, agent_id text NOT NULL, tool_pattern text NOT NULL,
+  action text NOT NULL, reason text, created_at integer NOT NULL, expires_at integer
+);
+CREATE TABLE IF NOT EXISTS approval_requests (
+  id text PRIMARY KEY NOT NULL, action text NOT NULL, params text, context text,
+  status text NOT NULL, urgency text NOT NULL, created_at integer NOT NULL,
+  updated_at integer NOT NULL, decided_at integer, decided_by text,
+  decision_reason text, expires_at integer, verified_agent_id text
+);
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id text PRIMARY KEY NOT NULL, request_id text NOT NULL, event_type text NOT NULL,
+  actor text NOT NULL, details text, created_at integer NOT NULL
+);
+`);
+
+vi.mock("../db/index.js", async () => ({
+  ...(await vi.importActual<typeof import("../db/schema.js")>("../db/schema.js")),
+  getDb: () => db,
+}));
+
+import { createAgent } from "../lib/agents.js";
+import mcpRouter from "../routes/mcp.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const TEST_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+
+// The api key the MCP server authenticates with — its agentId binding (a #13
+// virtual key) is the identity the guardrail keys on. Set per-test.
+let boundAgentId: string | null = null;
+
+function app() {
+  const a = new Hono();
+  a.use("*", async (c, next) => {
+    c.set("apiKey", boundAgentId ? ({ id: "k", agentId: boundAgentId } as never) : ({ id: "k", agentId: null } as never));
+    await next();
+  });
+  a.route("/api/mcp", mcpRouter);
+  return a;
+}
+
+function authorize(toolName: unknown, params: Record<string, unknown> = {}) {
+  return app().request("/api/mcp/authorize", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ toolName, params }),
+  });
+}
+
+function addOverride(agentId: string, toolPattern: string, expiresAt: number | null = null) {
+  sqlite
+    .prepare(
+      "INSERT INTO overrides (id, agent_id, tool_pattern, action, reason, created_at, expires_at) VALUES (?,?,?,?,?,?,?)",
+    )
+    .run(nanoid(), agentId, toolPattern, "require_approval", "metric breach", 1, expiresAt);
+}
+
+const countRequests = () =>
+  (sqlite.prepare("SELECT COUNT(*) n FROM approval_requests").get() as { n: number }).n;
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM agents; DELETE FROM overrides; DELETE FROM approval_requests; DELETE FROM audit_logs;");
+  boundAgentId = null;
+  setConfig(parseConfig({ jwtSecret: TEST_SECRET })); // authMode = "dual"
+});
+
+afterAll(() => {
+  resetConfig();
+  sqlite.close();
+});
+
+describe("POST /api/mcp/authorize", () => {
+  it("allows a tool when no override matches (no DB write)", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    boundAgentId = agent.id;
+    const res = await authorize("file.read");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ decision: "allow" });
+    expect(countRequests()).toBe(0);
+  });
+
+  it("gates a tool when a per-agent override matches → pending approval (acceptance a+b)", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    boundAgentId = agent.id;
+    addOverride(agent.id, "file.*");
+
+    const res = await authorize("file.read", { path: "/etc/passwd" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.decision).toBe("requires_approval");
+    expect(body.status).toBe("pending");
+    expect(typeof body.requestId).toBe("string");
+
+    const row = sqlite.prepare("SELECT * FROM approval_requests WHERE id = ?").get(body.requestId) as Record<string, unknown>;
+    expect(row.action).toBe("file.read");
+    expect(row.status).toBe("pending");
+    expect(row.verified_agent_id).toBe(agent.id);
+  });
+
+  it("respects glob tool patterns", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    boundAgentId = agent.id;
+    addOverride(agent.id, "file.read"); // exact
+
+    expect(((await (await authorize("file.read")).json()) as { decision: string }).decision).toBe("requires_approval");
+    expect(((await (await authorize("file.write")).json()) as { decision: string }).decision).toBe("allow");
+  });
+
+  it("tags the audit trail with OWASP LLM06 (acceptance c)", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    boundAgentId = agent.id;
+    addOverride(agent.id, "*");
+
+    const body = (await (await authorize("dangerous.tool")).json()) as { requestId: string };
+    const audit = sqlite.prepare("SELECT * FROM audit_logs WHERE request_id = ?").get(body.requestId) as Record<string, unknown>;
+    expect(audit.event_type).toBe("created");
+    expect(audit.actor).toBe("mcp");
+    const details = JSON.parse(audit.details as string) as Record<string, unknown>;
+    expect(details.toolName).toBe("dangerous.tool");
+    expect(details.owaspRisk).toBe("LLM06:2025 Excessive Agency");
+    expect(details.decision).toBe("requires_approval");
+    expect(details.verifiedAgentId).toBe(agent.id);
+  });
+
+  it("allows (fail-open) when no agent identity is presented, even if an override exists", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    addOverride(agent.id, "*");
+    boundAgentId = null; // api key has no virtual-key binding, no X-Agent headers
+    const res = await authorize("anything");
+    expect(((await res.json()) as { decision: string }).decision).toBe("allow");
+    expect(countRequests()).toBe(0);
+  });
+
+  it("ignores an expired override", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    boundAgentId = agent.id;
+    addOverride(agent.id, "*", 1); // expiresAt in the past (epoch 1)
+    expect(((await (await authorize("file.read")).json()) as { decision: string }).decision).toBe("allow");
+  });
+
+  it("rejects a missing toolName", async () => {
+    const { agent } = await createAgent("mcp-bot");
+    boundAgentId = agent.id;
+    expect((await authorize(undefined)).status).toBe(400);
+  });
+
+  it("403s when the key binding is to a revoked/unknown agent", async () => {
+    boundAgentId = "agt_ghost"; // bound to an agent that isn't in the registry
+    const res = await authorize("file.read");
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -19,6 +19,7 @@ import tokensRouter from "./routes/tokens.js";
 import decideRouter from "./routes/decide.js";
 import { createGuardrailsRouter } from "./routes/guardrails.js";
 import overridesRouter from "./routes/overrides.js";
+import mcpRouter from "./routes/mcp.js";
 import { startOverrideCleanup, stopOverrideCleanup } from "./routes/overrides.js";
 import channelsRouter from "./routes/channels.js";
 import escalationsRouter from "./routes/escalations.js";
@@ -195,6 +196,7 @@ app.use("/api/*", authMiddleware);
 
 // Mount API routes
 app.route("/api/requests", requestsRouter);
+app.route("/api/mcp", mcpRouter);
 app.route("/api", tokensRouter);
 app.route("/api/policies", policiesRouter);
 app.route("/api/api-keys", apiKeysRouter);

--- a/packages/server/src/lib/mcp-guardrails.ts
+++ b/packages/server/src/lib/mcp-guardrails.ts
@@ -12,11 +12,18 @@
 // the approval path, where an override forces pending and bypasses policy.
 
 import { nanoid } from "nanoid";
+import {
+  EventNames,
+  createBaseEvent,
+  getGlobalEmitter,
+  type RequestCreatedEvent,
+} from "@agentgate/core";
 
 import { getDb, approvalRequests } from "../db/index.js";
 import { checkOverrides } from "../routes/overrides.js";
 import { owaspRiskForPolicyDecision } from "./owasp.js";
 import { logAuditEvent } from "./audit.js";
+import { getGlobalDispatcher } from "./notification/index.js";
 
 export type McpAccessVerdict =
   | { decision: "allow" }
@@ -76,11 +83,29 @@ export async function evaluateMcpToolAccess(opts: {
 
   await logAuditEvent(id, "created", "mcp", {
     toolName,
+    params: params ?? {},
+    context: context ?? {},
     overrideId: match.overrideId,
     decision: "requires_approval",
     owaspRisk,
     verifiedAgentId,
   });
+
+  // Surface the pending request to humans the same way POST /api/requests does:
+  // emit the created event and dispatch a notification. No policy channels here
+  // (override-only gate) → the dispatcher falls back to configured/default routes.
+  const createdEvent: RequestCreatedEvent = {
+    ...createBaseEvent(EventNames.REQUEST_CREATED, "server"),
+    payload: {
+      requestId: id,
+      action: toolName,
+      params: params ?? {},
+      context: { ...(context ?? {}), source: "mcp" },
+      urgency: "normal",
+    },
+  };
+  getGlobalEmitter().emitSync(createdEvent);
+  getGlobalDispatcher().dispatchSync(createdEvent, undefined);
 
   return {
     decision: "requires_approval",

--- a/packages/server/src/lib/mcp-guardrails.ts
+++ b/packages/server/src/lib/mcp-guardrails.ts
@@ -1,0 +1,92 @@
+// @agentgate/server — MCP tool-call guardrails (issue #14).
+//
+// Enforce per-agent tool allow-listing at the MCP protocol boundary, right
+// before a tool executes. Reuses the agent-identity spine (#12): the gate is
+// keyed on the VERIFIED agent id, never a client-claimed one. A matching
+// per-agent override (the existing dynamic-override mechanism) escalates the
+// tool call to the human approval flow instead of letting it run.
+//
+// Precedence: this override gate runs FIRST, before the tool executes and
+// before any approval request the tool itself would create. Static policy
+// evaluation is intentionally NOT run here — matching checkOverrides' role in
+// the approval path, where an override forces pending and bypasses policy.
+
+import { nanoid } from "nanoid";
+
+import { getDb, approvalRequests } from "../db/index.js";
+import { checkOverrides } from "../routes/overrides.js";
+import { owaspRiskForPolicyDecision } from "./owasp.js";
+import { logAuditEvent } from "./audit.js";
+
+export type McpAccessVerdict =
+  | { decision: "allow" }
+  | {
+      decision: "requires_approval";
+      status: "pending";
+      requestId: string;
+      reason: string | null;
+      owaspRisk: string;
+    };
+
+/**
+ * Decide whether an MCP tool call may execute for a verified agent.
+ *
+ * `verifiedAgentId` MUST be the cryptographically resolved id (see routes/mcp).
+ * null means no agent identity was presented — overrides are per-agent, so
+ * there is nothing to enforce and the call is allowed (fail-open). When a
+ * per-agent override matches the tool, the call is escalated: a pending
+ * approval request is created (reusing the normal flow) and the tool does NOT
+ * run; the caller resolves it through the existing approve/deny path.
+ */
+export async function evaluateMcpToolAccess(opts: {
+  verifiedAgentId: string | null;
+  toolName: string;
+  params?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}): Promise<McpAccessVerdict> {
+  const { verifiedAgentId, toolName, params, context } = opts;
+  if (!verifiedAgentId) return { decision: "allow" };
+
+  const match = await checkOverrides(verifiedAgentId, toolName);
+  if (!match) return { decision: "allow" };
+
+  // Override matched → escalate to a pending approval request (Excessive Agency).
+  const id = nanoid();
+  const now = new Date();
+  // route_to_human is the gating decision; owasp maps it to LLM06.
+  const owaspRisk = owaspRiskForPolicyDecision("route_to_human")!;
+
+  await getDb()
+    .insert(approvalRequests)
+    .values({
+      id,
+      action: toolName,
+      params: JSON.stringify(params ?? {}),
+      context: JSON.stringify({ ...(context ?? {}), source: "mcp" }),
+      status: "pending",
+      urgency: "normal",
+      createdAt: now,
+      updatedAt: now,
+      decidedAt: null,
+      decidedBy: null,
+      decisionReason: `MCP tool gated by override: ${match.reason ?? "dynamic override"}`,
+      expiresAt: null,
+      verifiedAgentId,
+    });
+
+  await logAuditEvent(id, "created", "mcp", {
+    toolName,
+    overrideId: match.overrideId,
+    decision: "requires_approval",
+    owaspRisk,
+    verifiedAgentId,
+  });
+
+  return {
+    decision: "requires_approval",
+    status: "pending",
+    requestId: id,
+    reason: match.reason,
+    owaspRisk,
+  };
+}

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -1,0 +1,58 @@
+// @agentgate/server — MCP guardrail endpoint (issue #14).
+// POST /api/mcp/authorize — the MCP server calls this before executing a tool.
+// Mounted behind the normal /api/* auth middleware, so the caller's api key
+// (and any virtual-key agent binding, #13) is available on the context.
+
+import { Hono } from "hono";
+
+import { resolveVerifiedAgentId, resolveEffectiveAgentId } from "../lib/agent-tokens.js";
+import { evaluateMcpToolAccess } from "../lib/mcp-guardrails.js";
+import { getConfig } from "../config.js";
+import type { ApiKey } from "../db/schema.js";
+
+const mcpRouter = new Hono<{ Variables: { apiKey?: ApiKey } }>();
+
+mcpRouter.post("/authorize", async (c) => {
+  const body = (await c.req.json().catch(() => null)) as {
+    toolName?: unknown;
+    params?: Record<string, unknown>;
+    context?: Record<string, unknown>;
+  } | null;
+  if (!body || typeof body.toolName !== "string" || !body.toolName.trim()) {
+    return c.json({ error: "toolName is required" }, 400);
+  }
+
+  // Same verified-identity resolution as POST /api/requests: prefer an agent
+  // Bearer token / X-Agent-* headers, else the virtual-key binding on the api
+  // key the MCP server authenticated with.
+  const verifiedAgentId = await resolveVerifiedAgentId(
+    {
+      agentToken: c.req.header("x-agent-token"),
+      agentId: c.req.header("x-agent-id"),
+      agentSecret: c.req.header("x-agent-secret"),
+    },
+    getConfig().authMode,
+  );
+  const resolved = await resolveEffectiveAgentId(c.get("apiKey")?.agentId ?? null, verifiedAgentId);
+  if ("reject" in resolved) {
+    return c.json(
+      {
+        error:
+          resolved.reject === "conflict"
+            ? "API key is bound to a different agent than the request claims"
+            : "API key is bound to a revoked or unknown agent",
+      },
+      403,
+    );
+  }
+
+  const verdict = await evaluateMcpToolAccess({
+    verifiedAgentId: resolved.agentId,
+    toolName: body.toolName,
+    params: body.params,
+    context: body.context,
+  });
+  return c.json(verdict, 200);
+});
+
+export default mcpRouter;


### PR DESCRIPTION
## Issue #14 — PR1: MCP tool-call guardrails

Enforce per-agent tool allow-listing at the **MCP protocol boundary, right before a tool executes** — the differentiator that plugs governance upstream of execution. Built on the merged agent-identity spine (#12) + virtual keys (#13).

### How it works
- **`POST /api/mcp/authorize`** (`routes/mcp.ts`, mounted behind the normal `/api/*` auth): the MCP server calls this from its `CallTool` handler before dispatching a tool. It resolves the **verified effective agent id** exactly like `POST /api/requests` (agent token / `X-Agent-*` headers, else the virtual-key binding on the api key the MCP server authenticated with), and 403s a conflicting/revoked binding.
- **`lib/mcp-guardrails.ts` `evaluateMcpToolAccess`** keys the gate on that verified id and reuses the existing dynamic-override mechanism (`checkOverrides` + `matchToolPattern` glob), OWASP tagging, and the approval-request + audit tables.
- **`packages/mcp`**: the `CallTool` handler calls `authorizeTool` before `handleToolCall`; a `requires_approval` verdict returns `{status:"pending", requestId}` and the tool **does not run**. The MCP server's identity is simply the agent its api key is bound to (#13) — so no MCP-client credential plumbing was needed.

### Outcomes
| Verdict | Trigger | Behavior |
|---|---|---|
| **allow** | no override matches, or no verified agent | tool runs normally; no DB write |
| **requires_approval** | a per-agent override matches the tool | a pending `approval_requests` row is created (`action=toolName`, `verifiedAgentId` stamped), audited + **notified** (`request.created` event → dispatch), OWASP **LLM06** tagged; tool does not run; caller resolves via the existing approve/deny flow |

### Security & design
- **Keyed on the cryptographically verified identity**, never a tool arg — the gate can't be spoofed. (The adversarial review's security/bypass dimension found nothing.)
- **Precedence**: the override gate runs *before* tool execution and before any approval request the tool itself would create.
- **Fail-open by design**: overrides are per-agent, so an unidentified caller — or a transient `authorize` network failure — is allowed; the gate only ever *escalates to a human*, never hard-denies. (`ponytail:` a strict/fail-closed flag is a documented follow-up.)
- **Zero schema changes** — reuses `overrides` / `approval_requests` / `audit_logs`. Audit queryability by tool name comes free via the existing `GET /api/audit?action=<toolName>` join.

### Reviewed
35-agent adversarial review across security/bypass, correctness/parity, integration/regression, and test quality. **No fix-now findings; no security issue.** Its substantive follow-ups are addressed in the second commit:
- gated calls now **emit `request.created` + dispatch a notification** (a human-escalation gate that didn't notify the human was the main gap);
- audit details include `params`/`context` (parity);
- new `authorizeTool` tests cover the verdict pass-through + the network-error fail-open seam.

### Out of scope (follow-ups on #14)
CLI/dashboard for tool policies, a hard-`deny` override value + synchronous MCP error (the seam already supports a dormant branch), tool-invocation rate limits, redaction, `X-Agent-Token` header propagation from the MCP client.

### Tests
**+12**: 9 server (allow / gate→pending / glob / **event emission** / OWASP-audit / fail-open-no-identity / expired-override / missing-toolName / 403-revoked-binding) and 3 MCP (`authorizeTool` verdict pass-through + network-error fail-open). Server 657/658 (the one failure is the env-dependent Redis-fallback test, unrelated); MCP 48/48. typecheck + eslint clean across both packages.

Closes part of #14.
