### PR TITLE
feat(server): per-agent spend reads from AgentLens (#13)

### DIFF
--- a/packages/server/src/__tests__/agent-spend.test.ts
+++ b/packages/server/src/__tests__/agent-spend.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-agent spend reads from AgentLens (#13) — lib/agent-spend + GET /:id/spend.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+
+import {
+  fetchAgentSpend,
+  currentMonthWindow,
+  clearSpendCache,
+  SpendNotConfiguredError,
+} from "../lib/agent-spend.js";
+import agentsRouter from "../routes/agents.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const CONFIGURED = { agentlensUrl: "https://lens.example", agentgateServiceToken: "svc-token" };
+
+function mockFetch(body: unknown, ok = true) {
+  const fn = vi.fn(async () => ({ ok, status: ok ? 200 : 500, json: async () => body, text: async () => "" }) as Response);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+beforeEach(() => {
+  clearSpendCache();
+  setConfig(parseConfig(CONFIGURED));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetConfig();
+});
+
+describe("currentMonthWindow", () => {
+  it("anchors `from` at the 1st of the month in UTC", () => {
+    const w = currentMonthWindow(new Date("2026-06-17T13:45:00Z"));
+    expect(w.from).toBe("2026-06-01T00:00:00.000Z");
+    expect(w.to).toBe("2026-06-17T13:45:00.000Z");
+  });
+});
+
+describe("fetchAgentSpend", () => {
+  it("throws SpendNotConfiguredError when AgentLens isn't configured", async () => {
+    setConfig(parseConfig({})); // no url/token
+    await expect(fetchAgentSpend(["agt_a"], "default")).rejects.toBeInstanceOf(SpendNotConfiguredError);
+  });
+
+  it("returns a spend map, defaulting agents AgentLens omits to 0", async () => {
+    mockFetch({ spend: [{ agentId: "agt_a", totalCostUsd: 12.5, lastEventAt: null }] });
+    const m = await fetchAgentSpend(["agt_a", "agt_b"], "default");
+    expect(m.get("agt_a")).toBe(12.5);
+    expect(m.get("agt_b")).toBe(0); // not in response → 0
+  });
+
+  it("POSTs agentIds/tenantId/window to /api/internal/spend with the service token", async () => {
+    const fn = mockFetch({ spend: [] });
+    await fetchAgentSpend(["agt_a"], "tenant-x", { from: "2026-06-01T00:00:00Z", to: "2026-06-30T00:00:00Z" });
+    const [url, init] = fn.mock.calls[0]!;
+    expect(String(url)).toBe("https://lens.example/api/internal/spend");
+    expect((init as { method: string }).method).toBe("POST");
+    expect((init as { headers: Record<string, string> }).headers["Authorization"]).toBe("Bearer svc-token");
+    expect(JSON.parse((init as { body: string }).body)).toMatchObject({ agentIds: ["agt_a"], tenantId: "tenant-x" });
+  });
+
+  it("caches within the TTL (one fetch for repeated identical reads)", async () => {
+    const fn = mockFetch({ spend: [{ agentId: "agt_a", totalCostUsd: 1, lastEventAt: null }] });
+    await fetchAgentSpend(["agt_a"], "default");
+    await fetchAgentSpend(["agt_a"], "default");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GET /api/agents/:id/spend", () => {
+  function app() {
+    const a = new Hono();
+    a.use("*", async (c, next) => {
+      c.set("auth", { identity: { type: "api_key" }, tenantId: "default", permissions: ["*"] } as never);
+      await next();
+    });
+    a.route("/api/agents", agentsRouter);
+    return a;
+  }
+
+  it("returns the agent's current-month spend", async () => {
+    mockFetch({ spend: [{ agentId: "agt_a", totalCostUsd: 7.25, lastEventAt: null }] });
+    const res = await app().request("/api/agents/agt_a/spend");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { agentId: string; periodSpendUsd: number };
+    expect(body.agentId).toBe("agt_a");
+    expect(body.periodSpendUsd).toBe(7.25);
+  });
+
+  it("503s when AgentLens isn't configured", async () => {
+    setConfig(parseConfig({}));
+    const res = await app().request("/api/agents/agt_a/spend");
+    expect(res.status).toBe(503);
+  });
+
+  it("502s on an AgentLens upstream error", async () => {
+    mockFetch({ error: "boom" }, false);
+    const res = await app().request("/api/agents/agt_a/spend");
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -216,6 +216,13 @@ export const ConfigSchema = z.object({
   /** Refresh token TTL in seconds (default: 604800 = 7 days) */
   jwtRefreshTtl: z.coerce.number().int().min(60).default(604800),
 
+  // ─── Per-agent spend / budgets (#13) ────────────────────────────────
+  /** AgentLens base URL — source of per-agent spend telemetry. Unset = spend
+   *  reads disabled. */
+  agentlensUrl: z.string().optional(),
+  /** Shared service token for AgentLens' POST /api/internal/spend. */
+  agentgateServiceToken: z.string().optional(),
+
   // Metrics
   /** Enable Prometheus metrics endpoint (default true) */
   metricsEnabled: z
@@ -298,6 +305,8 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   AUTH_MODE: "authMode",
   JWT_ACCESS_TTL: "jwtAccessTtl",
   JWT_REFRESH_TTL: "jwtRefreshTtl",
+  AGENTLENS_URL: "agentlensUrl",
+  AGENTGATE_SERVICE_TOKEN: "agentgateServiceToken",
 };
 
 // ============================================================================
@@ -312,6 +321,7 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
 const SECRET_KEYS = [
   "ADMIN_API_KEY",
   "JWT_SECRET",
+  "AGENTGATE_SERVICE_TOKEN",
   "DATABASE_URL",
   "REDIS_URL",
   "SLACK_BOT_TOKEN",

--- a/packages/server/src/lib/agent-spend.ts
+++ b/packages/server/src/lib/agent-spend.ts
@@ -1,0 +1,96 @@
+// @agentgate/server — Per-agent spend reads from AgentLens (#13).
+//
+// AgentGate doesn't observe LLM tokens itself; it reads priced per-agent spend
+// from AgentLens' POST /api/internal/spend (authenticated by the shared
+// AGENTGATE_SERVICE_TOKEN). Results are cached briefly so a burst of budget
+// checks doesn't hammer AgentLens. This is the read side; budget enforcement
+// (checkAgentBudget) builds on it.
+
+import { AgentGateHttpClient } from "@agentgate/core";
+import { getConfig } from "../config.js";
+import { getLogger } from "./logger.js";
+
+/** Thrown when AGENTLENS_URL / AGENTGATE_SERVICE_TOKEN are not configured. */
+export class SpendNotConfiguredError extends Error {
+  constructor() {
+    super("Spend tracking not configured (set AGENTLENS_URL and AGENTGATE_SERVICE_TOKEN)");
+    this.name = "SpendNotConfiguredError";
+  }
+}
+
+export interface SpendWindow {
+  from: string;
+  to: string;
+}
+
+interface SpendRow {
+  agentId: string;
+  totalCostUsd: number;
+  lastEventAt: string | null;
+}
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { rows: SpendRow[]; at: number }>();
+
+/** Clear the spend cache (testing). */
+export function clearSpendCache(): void {
+  cache.clear();
+}
+
+/** The current calendar-month window in UTC: [1st 00:00:00, now]. */
+export function currentMonthWindow(now = new Date()): SpendWindow {
+  const from = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+  return { from, to: now.toISOString() };
+}
+
+function toSpendMap(rows: SpendRow[], agentIds: string[]): Map<string, number> {
+  // Agents AgentLens didn't return have no spend → default to 0.
+  const m = new Map<string, number>(agentIds.map((id) => [id, 0]));
+  for (const r of rows) m.set(r.agentId, Number(r.totalCostUsd) || 0);
+  return m;
+}
+
+/**
+ * Fetch per-agent USD spend over a window (default: current month), keyed on the
+ * verified agent ids. Returns a map agentId → spend (0 for agents with none).
+ * Cached for {@link CACHE_TTL_MS}. Throws SpendNotConfiguredError when AgentLens
+ * isn't configured; propagates upstream/network errors to the caller.
+ */
+export async function fetchAgentSpend(
+  agentIds: string[],
+  tenantId: string,
+  window?: SpendWindow,
+): Promise<Map<string, number>> {
+  const config = getConfig();
+  if (!config.agentlensUrl || !config.agentgateServiceToken) {
+    throw new SpendNotConfiguredError();
+  }
+  if (agentIds.length === 0) return new Map();
+
+  const w = window ?? currentMonthWindow();
+  // Quantize the window END into a CACHE_TTL_MS bucket so reads seconds apart
+  // share a key (the raw `to` is ~now at ms precision, which would otherwise make
+  // every call a cache miss). `from` keeps distinct periods separate.
+  const toBucket = Math.floor(Date.parse(w.to) / CACHE_TTL_MS);
+  const key = `${tenantId}|${w.from}|${toBucket}|${[...agentIds].sort().join(",")}`;
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && now - hit.at < CACHE_TTL_MS) {
+    return toSpendMap(hit.rows, agentIds);
+  }
+
+  const client = new AgentGateHttpClient(config.agentlensUrl, config.agentgateServiceToken);
+  const res = await client.request<{ spend: SpendRow[] }>("POST", "/api/internal/spend", {
+    agentIds,
+    tenantId,
+    from: w.from,
+    to: w.to,
+  });
+  const rows = Array.isArray(res?.spend) ? res.spend : [];
+  cache.set(key, { rows, at: now });
+  getLogger().debug(
+    { agentCount: agentIds.length, returned: rows.length, tenantId },
+    "fetched agent spend from AgentLens",
+  );
+  return toSpendMap(rows, agentIds);
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -6,9 +6,11 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 
 import { createAgent, listAgents, revokeAgent } from "../lib/agents.js";
+import { fetchAgentSpend, currentMonthWindow, SpendNotConfiguredError } from "../lib/agent-spend.js";
 import { requirePermission } from "../middleware/auth.js";
 
-const router = new Hono();
+// Variables: the auth middleware sets `auth` (carries the tenant) on the context.
+const router = new Hono<{ Variables: { auth?: { tenantId?: string } } }>();
 
 // Registering/revoking agent credentials is admin-level credential management.
 router.use("*", requirePermission("keys:manage"));
@@ -36,6 +38,28 @@ router.post("/", zValidator("json", createAgentSchema), async (c) => {
 // List agents (without secrets).
 router.get("/", async (c) => {
   return c.json({ agents: await listAgents() });
+});
+
+// Per-agent spend report for the current calendar month (#13). Reads priced
+// spend from AgentLens; informational (enforcement is checkAgentBudget).
+router.get("/:id/spend", async (c) => {
+  const id = c.req.param("id");
+  const tenantId = c.get("auth")?.tenantId ?? "default";
+  const window = currentMonthWindow();
+  try {
+    const spend = await fetchAgentSpend([id], tenantId, window);
+    return c.json({
+      agentId: id,
+      tenantId,
+      periodSpendUsd: spend.get(id) ?? 0,
+      window,
+    });
+  } catch (err) {
+    if (err instanceof SpendNotConfiguredError) {
+      return c.json({ error: err.message }, 503);
+    }
+    return c.json({ error: "Failed to fetch spend from AgentLens" }, 502);
+  }
 });
 
 // Revoke an agent.


### PR DESCRIPTION
## Per-agent spend reads from AgentLens (#13, AG-PR4)

The consuming side of per-agent budgets: AgentGate can't observe LLM tokens itself, so it reads **priced** per-agent spend from AgentLens (`POST /api/internal/spend`, shipped in agentlens#58) to later enforce budgets. **Read side only — no enforcement in this PR.**

### What's in
- **`lib/agent-spend`** — `fetchAgentSpend(agentIds, tenantId, window?)` calls AgentLens via the shared `AgentGateHttpClient` (the `AGENTGATE_SERVICE_TOKEN` as Bearer), returns a `Map<agentId, usd>` defaulting agents AgentLens omits to **$0**. `currentMonthWindow()` anchors the calendar-month period in UTC. Throws `SpendNotConfiguredError` when `AGENTLENS_URL` / `AGENTGATE_SERVICE_TOKEN` are unset.
- **30s in-memory cache** keyed on tenant + period + **quantized** window-end + agent set, so a burst of budget checks hits AgentLens at most once per 30s (staleness ceiling = 30s).
- **`GET /api/agents/:id/spend`** (admin, `keys:manage`) — current-month spend report; `503` when unconfigured, `502` on an AgentLens upstream error.
- **config** — `AGENTLENS_URL` + `AGENTGATE_SERVICE_TOKEN` (the latter `_FILE`-secret aware).

### Caught while building
The cache key originally included the raw window-end (`now` at ms precision), so the 30s cache would have **never hit** in production — every call recomputes a fresh end. Fixed by quantizing the end into a 30s bucket; the test is now deterministic rather than relying on same-millisecond timing.

### Reviewed
Focused adversarial review (cache/correctness + security/ops): **0 confirmed findings** — token handling to AgentLens, error mapping (503/502, no 500 leak), and the `default` tenant all sound; the cache bug above was already fixed when verified.

### Out of scope (AG-PR5, next)
`agents.monthlyBudgetUsd` + `checkAgentBudget` + enforcement in the requests route (behind a flag).

### Tests
+8 (config gating → `SpendNotConfiguredError`, fetch with correct token header + body, cache hit, $0-defaulting, month-window anchoring, endpoint 200/503/502). Full server suite green (the one failure is the env-dependent Redis-fallback test, unrelated). typecheck + lint clean.
