### PR TITLE
feat(server): per-agent budget enforcement (#13)

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -114,7 +114,7 @@ export interface RequestDecidedEvent
     action: string;
     status: Extract<ApprovalStatus, "approved" | "denied">;
     decidedBy: string;
-    decidedByType: "human" | "agent" | "policy";
+    decidedByType: "human" | "agent" | "policy" | "budget_limiter";
     reason?: string;
     /** Time from creation to decision in milliseconds */
     decisionTimeMs: number;

--- a/packages/server/drizzle/postgres/0007_bitter_mimic.sql
+++ b/packages/server/drizzle/postgres/0007_bitter_mimic.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "agents" ADD COLUMN "monthly_budget_usd" double precision;

--- a/packages/server/drizzle/postgres/meta/0007_snapshot.json
+++ b/packages/server/drizzle/postgres/meta/0007_snapshot.json
@@ -1,0 +1,1139 @@
+{
+  "id": "f14e46e1-b76b-442b-9d60-d1f0f8c60249",
+  "prevId": "83189179-d97e-4bda-8f28-b499b048e509",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_budget_usd": {
+          "name": "monthly_budget_usd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decision_tokens": {
+      "name": "decision_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_history": {
+      "name": "escalation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_rules": {
+      "name": "escalation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overrides": {
+      "name": "overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policies": {
+      "name": "policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_ids": {
+          "name": "tool_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oidc_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/postgres/meta/_journal.json
+++ b/packages/server/drizzle/postgres/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782140779704,
       "tag": "0006_nice_bloodscream",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782153026280,
+      "tag": "0007_bitter_mimic",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/sqlite/0010_jazzy_havok.sql
+++ b/packages/server/drizzle/sqlite/0010_jazzy_havok.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `agents` ADD `monthly_budget_usd` real;

--- a/packages/server/drizzle/sqlite/meta/0010_snapshot.json
+++ b/packages/server/drizzle/sqlite/meta/0010_snapshot.json
@@ -1,0 +1,1070 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "788eb4bd-ba22-4329-bd93-f32d3ac513ba",
+  "prevId": "bd77fc43-47b5-49c1-a34f-4f23468d2ee6",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_budget_usd": {
+          "name": "monthly_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approval_requests": {
+      "name": "approval_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_tokens": {
+      "name": "decision_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_history": {
+      "name": "escalation_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            "rule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_rules": {
+      "name": "escalation_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            "policy_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "overrides": {
+      "name": "overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_ids": {
+          "name": "tool_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refresh_tokens": {
+      "name": "refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": true
+        },
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/sqlite/meta/_journal.json
+++ b/packages/server/drizzle/sqlite/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1782140777171,
       "tag": "0009_tranquil_thaddeus_ross",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1782153025138,
+      "tag": "0010_jazzy_havok",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/agent-budget.test.ts
+++ b/packages/server/src/__tests__/agent-budget.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Per-agent budget enforcement (#13) — checkAgentBudget + admin budget routes.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import * as schema from "../db/schema.js";
+
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+
+sqlite.exec(`
+CREATE TABLE IF NOT EXISTS agents (
+  id text PRIMARY KEY NOT NULL, name text NOT NULL, secret_hash text NOT NULL,
+  status text NOT NULL, metadata text, created_at integer NOT NULL,
+  last_seen_at integer, revoked_at integer, monthly_budget_usd real
+);
+`);
+
+vi.mock("../db/index.js", async () => ({
+  ...(await vi.importActual<typeof import("../db/schema.js")>("../db/schema.js")),
+  getDb: () => db,
+}));
+
+import { createAgent, getAgentBudget, setAgentBudget } from "../lib/agents.js";
+import { checkAgentBudget } from "../lib/agent-budget.js";
+import { clearSpendCache } from "../lib/agent-spend.js";
+import agentsRouter from "../routes/agents.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const LENS = { agentlensUrl: "https://lens.example", agentgateServiceToken: "svc" };
+
+function mockSpend(usdByAgent: Record<string, number>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        spend: Object.entries(usdByAgent).map(([agentId, totalCostUsd]) => ({ agentId, totalCostUsd, lastEventAt: null })),
+      }),
+    }) as Response),
+  );
+}
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM agents");
+  clearSpendCache();
+  setConfig(parseConfig(LENS));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetConfig();
+});
+
+describe("checkAgentBudget", () => {
+  it("allows an agent with no budget (limit null)", async () => {
+    const { agent } = await createAgent("ci"); // no budget
+    mockSpend({ [agent.id]: 999 });
+    const v = await checkAgentBudget(agent.id, "default");
+    expect(v).toMatchObject({ allowed: true, limitUsd: null });
+  });
+
+  it("allows when under budget", async () => {
+    const { agent } = await createAgent("ci", null, 100);
+    mockSpend({ [agent.id]: 40 });
+    const v = await checkAgentBudget(agent.id, "default");
+    expect(v.allowed).toBe(true);
+    expect(v.spentUsd).toBe(40);
+    expect(v.limitUsd).toBe(100);
+  });
+
+  it("denies when spend has reached/exceeded the budget", async () => {
+    const { agent } = await createAgent("ci", null, 100);
+    mockSpend({ [agent.id]: 150 });
+    expect((await checkAgentBudget(agent.id, "default")).allowed).toBe(false);
+    clearSpendCache();
+    mockSpend({ [agent.id]: 100 }); // exactly at limit → denied (spent < limit is false)
+    expect((await checkAgentBudget(agent.id, "default")).allowed).toBe(false);
+  });
+
+  it("fails OPEN when AgentLens is unconfigured", async () => {
+    const { agent } = await createAgent("ci", null, 100);
+    setConfig(parseConfig({})); // no AgentLens
+    expect((await checkAgentBudget(agent.id, "default")).allowed).toBe(true);
+  });
+
+  it("fails OPEN when the spend fetch errors", async () => {
+    const { agent } = await createAgent("ci", null, 100);
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500, text: async () => "" }) as Response));
+    expect((await checkAgentBudget(agent.id, "default")).allowed).toBe(true);
+  });
+});
+
+describe("agent budget storage + admin routes", () => {
+  function app() {
+    const a = new Hono();
+    a.use("*", async (c, next) => {
+      c.set("auth", { identity: { type: "api_key" }, tenantId: "default", permissions: ["*"] } as never);
+      await next();
+    });
+    a.route("/api/agents", agentsRouter);
+    return a;
+  }
+
+  it("createAgent persists a budget; getAgentBudget reads it", async () => {
+    const { agent } = await createAgent("ci", null, 250.5);
+    expect(await getAgentBudget(agent.id)).toBe(250.5);
+  });
+
+  it("setAgentBudget sets and clears; returns false for a missing agent", async () => {
+    const { agent } = await createAgent("ci");
+    expect(await setAgentBudget(agent.id, 50)).toBe(true);
+    expect(await getAgentBudget(agent.id)).toBe(50);
+    expect(await setAgentBudget(agent.id, null)).toBe(true);
+    expect(await getAgentBudget(agent.id)).toBeNull();
+    expect(await setAgentBudget("agt_missing", 10)).toBe(false);
+  });
+
+  it("PATCH /api/agents/:id/budget updates the cap", async () => {
+    const { agent } = await createAgent("ci");
+    const res = await app().request(`/api/agents/${agent.id}/budget`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ monthlyBudgetUsd: 75 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await getAgentBudget(agent.id)).toBe(75);
+  });
+
+  it("PATCH on a missing agent → 404", async () => {
+    const res = await app().request("/api/agents/agt_nope/budget", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ monthlyBudgetUsd: 10 }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/server/src/__tests__/agent-tokens.test.ts
+++ b/packages/server/src/__tests__/agent-tokens.test.ts
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS agents (
   metadata text,
   created_at integer NOT NULL,
   last_seen_at integer,
-  revoked_at integer
+  revoked_at integer,
+  monthly_budget_usd real
 );
 `);
 

--- a/packages/server/src/__tests__/agents.test.ts
+++ b/packages/server/src/__tests__/agents.test.ts
@@ -18,7 +18,8 @@ CREATE TABLE IF NOT EXISTS agents (
   metadata text,
   created_at integer NOT NULL,
   last_seen_at integer,
-  revoked_at integer
+  revoked_at integer,
+  monthly_budget_usd real
 );
 CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
 `);

--- a/packages/server/src/__tests__/mcp-guardrails.test.ts
+++ b/packages/server/src/__tests__/mcp-guardrails.test.ts
@@ -15,7 +15,7 @@ sqlite.exec(`
 CREATE TABLE IF NOT EXISTS agents (
   id text PRIMARY KEY NOT NULL, name text NOT NULL, secret_hash text NOT NULL,
   status text NOT NULL, metadata text, created_at integer NOT NULL,
-  last_seen_at integer, revoked_at integer
+  last_seen_at integer, revoked_at integer, monthly_budget_usd real
 );
 CREATE TABLE IF NOT EXISTS overrides (
   id text PRIMARY KEY NOT NULL, agent_id text NOT NULL, tool_pattern text NOT NULL,

--- a/packages/server/src/__tests__/request-decision.test.ts
+++ b/packages/server/src/__tests__/request-decision.test.ts
@@ -1,0 +1,55 @@
+/**
+ * decideInitialStatus — the budget > override > policy precedence (#13).
+ * This is the real decision logic the requests route runs.
+ */
+import { describe, it, expect } from "vitest";
+import type { PolicyDecision } from "@agentgate/core";
+import { decideInitialStatus } from "../lib/request-decision.js";
+
+const NOW = new Date("2026-06-22T00:00:00Z");
+const approve: PolicyDecision = { decision: "auto_approve" };
+const deny: PolicyDecision = { decision: "auto_deny" };
+const human: PolicyDecision = { decision: "route_to_human" };
+const override = { reason: "metric breach" };
+
+function decide(over: typeof override | null, pol: PolicyDecision, budgetReason: string | null = null) {
+  return decideInitialStatus({ budgetReason, overrideMatch: over, policyDecision: pol, now: NOW });
+}
+
+describe("decideInitialStatus precedence", () => {
+  it("budget deny beats an auto_approve policy", () => {
+    const d = decide(null, approve, "Monthly budget exceeded: $120.00 of $100.00 used");
+    expect(d.status).toBe("denied");
+    expect(d.decidedBy).toBe("budget");
+    expect(d.decidedByType).toBe("budget_limiter");
+    expect(d.decidedAt).toBe(NOW);
+    expect(d.decisionReason).toContain("budget exceeded");
+  });
+
+  it("budget deny beats an active override (which would otherwise route to human)", () => {
+    const d = decide(override, human, "over budget");
+    expect(d.status).toBe("denied");
+    expect(d.decidedByType).toBe("budget_limiter");
+  });
+
+  it("without a budget overage, an override forces pending (route to human)", () => {
+    const d = decide(override, approve);
+    expect(d.status).toBe("pending");
+    expect(d.decidedBy).toBeNull();
+    expect(d.decisionReason).toContain("Override active");
+  });
+
+  it("policy auto_approve / auto_deny apply when no budget or override", () => {
+    expect(decide(null, approve).status).toBe("approved");
+    expect(decide(null, approve).decidedBy).toBe("policy");
+    expect(decide(null, deny).status).toBe("denied");
+    expect(decide(null, deny).decidedByType).toBe("policy");
+  });
+
+  it("route_to_human stays pending with no decider", () => {
+    const d = decide(null, human);
+    expect(d.status).toBe("pending");
+    expect(d.decidedBy).toBeNull();
+    expect(d.decidedAt).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/setup.ts
+++ b/packages/server/src/__tests__/setup.ts
@@ -36,7 +36,8 @@ CREATE TABLE IF NOT EXISTS \`agents\` (
 	\`metadata\` text,
 	\`created_at\` integer NOT NULL,
 	\`last_seen_at\` integer,
-	\`revoked_at\` integer
+	\`revoked_at\` integer,
+	\`monthly_budget_usd\` real
 );
 
 CREATE TABLE IF NOT EXISTS \`audit_logs\` (

--- a/packages/server/src/__tests__/virtual-keys.test.ts
+++ b/packages/server/src/__tests__/virtual-keys.test.ts
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS agents (
   metadata text,
   created_at integer NOT NULL,
   last_seen_at integer,
-  revoked_at integer
+  revoked_at integer,
+  monthly_budget_usd real
 );
 `);
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -222,6 +222,12 @@ export const ConfigSchema = z.object({
   agentlensUrl: z.string().optional(),
   /** Shared service token for AgentLens' POST /api/internal/spend. */
   agentgateServiceToken: z.string().optional(),
+  /** Enforce per-agent monthly budgets (deny over-budget requests). Default off
+   *  so the feature ships dark until an operator opts in. */
+  agentBudgetEnforcement: z
+    .union([z.boolean(), z.string()])
+    .transform((val) => (typeof val === "boolean" ? val : ["true", "1", "yes"].includes(val.toLowerCase())))
+    .default(false),
 
   // Metrics
   /** Enable Prometheus metrics endpoint (default true) */
@@ -307,6 +313,7 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   JWT_REFRESH_TTL: "jwtRefreshTtl",
   AGENTLENS_URL: "agentlensUrl",
   AGENTGATE_SERVICE_TOKEN: "agentgateServiceToken",
+  AGENT_BUDGET_ENFORCEMENT: "agentBudgetEnforcement",
 };
 
 // ============================================================================

--- a/packages/server/src/db/schema.postgres.ts
+++ b/packages/server/src/db/schema.postgres.ts
@@ -1,7 +1,7 @@
 /**
  * PostgreSQL schema definition for AgentGate
  */
-import { pgTable, text, integer, timestamp, boolean, index } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, timestamp, boolean, doublePrecision, index } from "drizzle-orm/pg-core";
 
 // Approval requests table
 export const approvalRequests = pgTable("approval_requests", {
@@ -85,6 +85,7 @@ export const agents = pgTable("agents", {
   createdAt: timestamp("created_at", { mode: "date" }).notNull(),
   lastSeenAt: timestamp("last_seen_at", { mode: "date" }),
   revokedAt: timestamp("revoked_at", { mode: "date" }),
+  monthlyBudgetUsd: doublePrecision("monthly_budget_usd"), // per-agent USD cap; null = no budget (#13)
 }, (table) => ({
   idxAgentsStatus: index("idx_agents_status").on(table.status),
 }));

--- a/packages/server/src/db/schema.sqlite.ts
+++ b/packages/server/src/db/schema.sqlite.ts
@@ -1,7 +1,7 @@
 /**
  * SQLite schema definition for AgentGate
  */
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
 
 // Approval requests table
 export const approvalRequests = sqliteTable("approval_requests", {
@@ -89,6 +89,7 @@ export const agents = sqliteTable("agents", {
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
   lastSeenAt: integer("last_seen_at", { mode: "timestamp" }),
   revokedAt: integer("revoked_at", { mode: "timestamp" }),
+  monthlyBudgetUsd: real("monthly_budget_usd"), // per-agent USD cap; null = no budget (#13)
 }, (table) => ({
   idxAgentsStatus: index("idx_agents_status").on(table.status),
 }));

--- a/packages/server/src/lib/agent-budget.ts
+++ b/packages/server/src/lib/agent-budget.ts
@@ -1,0 +1,44 @@
+// @agentgate/server — Per-agent budget enforcement (#13).
+//
+// Compares an agent's current-month spend (read from AgentLens via
+// lib/agent-spend) against its configured monthly USD cap. This is a SOFT
+// guardrail: it gates the NEXT request once an agent is over budget — it cannot
+// stop in-flight LLM spend (AgentGate doesn't sit in the completion path), and
+// spend is cache-stale by up to the spend cache TTL. It also FAILS OPEN: if the
+// limit can't be evaluated (AgentLens unconfigured or unreachable) the request
+// is allowed, never blocked on a telemetry outage.
+
+import { getAgentBudget } from "./agents.js";
+import { fetchAgentSpend, SpendNotConfiguredError } from "./agent-spend.js";
+import { getLogger } from "./logger.js";
+
+export interface BudgetVerdict {
+  allowed: boolean;
+  /** The agent's cap, or null if it has no budget. */
+  limitUsd: number | null;
+  /** Current-month spend used for the decision. */
+  spentUsd: number;
+}
+
+/**
+ * Whether `agentId` is within its monthly budget. Agents with no cap are always
+ * allowed. Fails open (allowed) when spend can't be read.
+ */
+export async function checkAgentBudget(agentId: string, tenantId: string): Promise<BudgetVerdict> {
+  const limitUsd = await getAgentBudget(agentId);
+  if (limitUsd === null) return { allowed: true, limitUsd: null, spentUsd: 0 };
+
+  let spentUsd = 0;
+  try {
+    spentUsd = (await fetchAgentSpend([agentId], tenantId)).get(agentId) ?? 0;
+  } catch (err) {
+    // Fail open: a budget guardrail must never block requests because the
+    // telemetry source is down or unconfigured.
+    if (!(err instanceof SpendNotConfiguredError)) {
+      getLogger().warn({ err, agentId }, "agent budget check failed; allowing (fail-open)");
+    }
+    return { allowed: true, limitUsd, spentUsd: 0 };
+  }
+
+  return { allowed: spentUsd < limitUsd, limitUsd, spentUsd };
+}

--- a/packages/server/src/lib/agents.ts
+++ b/packages/server/src/lib/agents.ts
@@ -44,6 +44,7 @@ function toPublic(a: Agent): PublicAgent {
 export async function createAgent(
   name: string,
   metadata?: Record<string, unknown> | null,
+  monthlyBudgetUsd?: number | null,
 ): Promise<{ agent: PublicAgent; secret: string }> {
   const { id, secret } = generateAgentCredential();
   const now = new Date();
@@ -56,9 +57,28 @@ export async function createAgent(
     createdAt: now,
     lastSeenAt: null,
     revokedAt: null,
+    monthlyBudgetUsd: monthlyBudgetUsd ?? null,
   };
   await getDb().insert(agents).values(values);
   return { agent: toPublic(values), secret };
+}
+
+/** The agent's monthly USD budget cap, or null if it has none / doesn't exist. */
+export async function getAgentBudget(id: string): Promise<number | null> {
+  const rows = await getDb()
+    .select({ monthlyBudgetUsd: agents.monthlyBudgetUsd })
+    .from(agents)
+    .where(eq(agents.id, id))
+    .limit(1);
+  return rows[0]?.monthlyBudgetUsd ?? null;
+}
+
+/** Set or clear an agent's monthly USD budget. Returns false if missing. */
+export async function setAgentBudget(id: string, monthlyBudgetUsd: number | null): Promise<boolean> {
+  const rows = await getDb().select({ id: agents.id }).from(agents).where(eq(agents.id, id)).limit(1);
+  if (!rows[0]) return false;
+  await getDb().update(agents).set({ monthlyBudgetUsd }).where(eq(agents.id, id));
+  return true;
 }
 
 /**

--- a/packages/server/src/lib/request-decision.ts
+++ b/packages/server/src/lib/request-decision.ts
@@ -1,0 +1,72 @@
+// @agentgate/server — Initial decision for a new approval request.
+//
+// Precedence (highest first): a per-agent budget overage (#13) denies outright,
+// then a dynamic override forces human review (pending), then static policy
+// auto-approve/deny. Anything else stays pending. Extracted as a pure function
+// so the precedence is unit-testable without driving the whole request route.
+
+import type { PolicyDecision } from "@agentgate/core";
+
+export interface InitialDecision {
+  status: "pending" | "approved" | "denied";
+  decidedBy: string | null;
+  decidedByType: "policy" | "budget_limiter";
+  decidedAt: Date | null;
+  decisionReason: string | null;
+}
+
+export function decideInitialStatus(input: {
+  /** Non-null when the verified agent is over its budget; the reason string. */
+  budgetReason: string | null;
+  /** A matching dynamic override (forces human review), or null. */
+  overrideMatch: { reason?: string | null } | null;
+  policyDecision: PolicyDecision;
+  /** Decision timestamp, stamped on auto-decided (approved/denied) outcomes. */
+  now: Date;
+}): InitialDecision {
+  const { budgetReason, overrideMatch, policyDecision, now } = input;
+
+  if (budgetReason) {
+    return {
+      status: "denied",
+      decidedBy: "budget",
+      decidedByType: "budget_limiter",
+      decidedAt: now,
+      decisionReason: budgetReason,
+    };
+  }
+  if (overrideMatch) {
+    // Override forces require_approval → stays pending (route to human).
+    return {
+      status: "pending",
+      decidedBy: null,
+      decidedByType: "policy",
+      decidedAt: null,
+      decisionReason: `Override active: ${overrideMatch.reason || "dynamic override"}`,
+    };
+  }
+  if (policyDecision.decision === "auto_approve") {
+    return {
+      status: "approved",
+      decidedBy: "policy",
+      decidedByType: "policy",
+      decidedAt: now,
+      decisionReason: policyDecision.matchedRule
+        ? `Auto-approved by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
+        : "Auto-approved by policy",
+    };
+  }
+  if (policyDecision.decision === "auto_deny") {
+    return {
+      status: "denied",
+      decidedBy: "policy",
+      decidedByType: "policy",
+      decidedAt: now,
+      decisionReason: policyDecision.matchedRule
+        ? `Auto-denied by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
+        : "Auto-denied by policy",
+    };
+  }
+  // route_to_human and route_to_agent stay pending.
+  return { status: "pending", decidedBy: null, decidedByType: "policy", decidedAt: null, decisionReason: null };
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 
-import { createAgent, listAgents, revokeAgent } from "../lib/agents.js";
+import { createAgent, listAgents, revokeAgent, setAgentBudget } from "../lib/agents.js";
 import { fetchAgentSpend, currentMonthWindow, SpendNotConfiguredError } from "../lib/agent-spend.js";
 import { requirePermission } from "../middleware/auth.js";
 
@@ -18,12 +18,13 @@ router.use("*", requirePermission("keys:manage"));
 const createAgentSchema = z.object({
   name: z.string().min(1).max(100),
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  monthlyBudgetUsd: z.number().positive().nullable().optional(),
 });
 
 // Register a new agent — returns the secret ONCE.
 router.post("/", zValidator("json", createAgentSchema), async (c) => {
-  const { name, metadata } = c.req.valid("json");
-  const { agent, secret } = await createAgent(name, metadata ?? null);
+  const { name, metadata, monthlyBudgetUsd } = c.req.valid("json");
+  const { agent, secret } = await createAgent(name, metadata ?? null, monthlyBudgetUsd ?? null);
   return c.json(
     {
       ...agent,
@@ -60,6 +61,14 @@ router.get("/:id/spend", async (c) => {
     }
     return c.json({ error: "Failed to fetch spend from AgentLens" }, 502);
   }
+});
+
+// Set or clear an agent's monthly budget (null clears it).
+const budgetSchema = z.object({ monthlyBudgetUsd: z.number().positive().nullable() });
+router.patch("/:id/budget", zValidator("json", budgetSchema), async (c) => {
+  const ok = await setAgentBudget(c.req.param("id"), c.req.valid("json").monthlyBudgetUsd);
+  if (!ok) return c.json({ error: "Agent not found" }, 404);
+  return c.json({ id: c.req.param("id"), monthlyBudgetUsd: c.req.valid("json").monthlyBudgetUsd });
 });
 
 // Revoke an agent.

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -18,6 +18,7 @@ import { logAuditEvent } from "../lib/audit.js";
 import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
 import { resolveVerifiedAgentId, resolveEffectiveAgentId } from "../lib/agent-tokens.js";
 import { checkAgentBudget } from "../lib/agent-budget.js";
+import { decideInitialStatus } from "../lib/request-decision.js";
 import { getConfig } from "../config.js";
 import type { ApiKey } from "../db/schema.js";
 import { deliverWebhook } from "../lib/webhook.js";
@@ -279,39 +280,13 @@ requestsRouter.post("/", async (c) => {
     tool: action,
   });
 
-  // Determine initial status — budget deny takes precedence over override/policy.
-  let status: "pending" | "approved" | "denied" = "pending";
-  let decidedBy: string | null = null;
-  let decidedByType: "policy" | "budget_limiter" = "policy";
-  let decidedAt: Date | null = null;
-  let decisionReason: string | null = null;
-
-  if (budgetReason) {
-    status = "denied";
-    decidedBy = "budget";
-    decidedByType = "budget_limiter";
-    decidedAt = now;
-    decisionReason = budgetReason;
-  } else if (overrideMatch) {
-    // Override forces require_approval → stays pending (route to human)
-    status = "pending";
-    decisionReason = `Override active: ${overrideMatch.reason || "dynamic override"}`;
-  } else if (policyDecision.decision === "auto_approve") {
-    status = "approved";
-    decidedBy = "policy";
-    decidedAt = now;
-    decisionReason = policyDecision.matchedRule 
-      ? `Auto-approved by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
-      : "Auto-approved by policy";
-  } else if (policyDecision.decision === "auto_deny") {
-    status = "denied";
-    decidedBy = "policy";
-    decidedAt = now;
-    decisionReason = policyDecision.matchedRule
-      ? `Auto-denied by policy rule matching: ${JSON.stringify(policyDecision.matchedRule.match)}`
-      : "Auto-denied by policy";
-  }
-  // route_to_human and route_to_agent stay pending
+  // Determine initial status — budget deny > override > policy (see helper).
+  const { status, decidedBy, decidedByType, decidedAt, decisionReason } = decideInitialStatus({
+    budgetReason,
+    overrideMatch,
+    policyDecision,
+    now,
+  });
 
   // Insert into database
   await getDb().insert(approvalRequests).values({

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -17,6 +17,7 @@ import {
 import { logAuditEvent } from "../lib/audit.js";
 import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
 import { resolveVerifiedAgentId, resolveEffectiveAgentId } from "../lib/agent-tokens.js";
+import { checkAgentBudget } from "../lib/agent-budget.js";
 import { getConfig } from "../config.js";
 import type { ApiKey } from "../db/schema.js";
 import { deliverWebhook } from "../lib/webhook.js";
@@ -24,8 +25,9 @@ import { getGlobalDispatcher } from "../lib/notification/index.js";
 import { getCachedPolicies } from "../lib/policy-cache.js";
 import { checkOverrides } from "./overrides.js";
 
-// Variables: the auth middleware sets the validated apiKey row on api-key auth.
-const requestsRouter = new Hono<{ Variables: { apiKey?: ApiKey } }>();
+// Variables: the auth middleware sets the validated apiKey row + the auth
+// context (carries the tenant) on the request context.
+const requestsRouter = new Hono<{ Variables: { apiKey?: ApiKey; auth?: { tenantId?: string } } }>();
 
 // Validation helper for creating requests
 function validateCreateRequestBody(body: unknown): {
@@ -135,7 +137,7 @@ async function handleAutoDecision(opts: {
   action: string;
   status: "approved" | "denied";
   decidedBy: string;
-  decidedByType: "policy" | "human" | "agent";
+  decidedByType: "policy" | "human" | "agent" | "budget_limiter";
   decisionReason: string | null;
   requestSnapshot: Record<string, unknown>;
   channels?: string[];
@@ -253,6 +255,18 @@ requestsRouter.post("/", async (c) => {
   }
   const effectiveAgentId = resolved.agentId;
 
+  // Per-agent budget (issue #13): if enforcement is on and the verified agent is
+  // over its monthly cap, deny outright — this takes precedence over override /
+  // policy. Fail-open (checkAgentBudget never throws on a telemetry outage).
+  let budgetReason: string | null = null;
+  if (getConfig().agentBudgetEnforcement && effectiveAgentId) {
+    const tenantId = c.get("auth")?.tenantId ?? "default";
+    const budget = await checkAgentBudget(effectiveAgentId, tenantId);
+    if (!budget.allowed) {
+      budgetReason = `Monthly budget exceeded: $${budget.spentUsd.toFixed(2)} of $${budget.limitUsd?.toFixed(2)} used`;
+    }
+  }
+
   // Check overrides BEFORE static policies, keyed on the VERIFIED agent id.
   let overrideMatch: Awaited<ReturnType<typeof checkOverrides>> = null;
   if (effectiveAgentId) {
@@ -265,13 +279,20 @@ requestsRouter.post("/", async (c) => {
     tool: action,
   });
 
-  // Determine initial status based on override or policy decision
+  // Determine initial status — budget deny takes precedence over override/policy.
   let status: "pending" | "approved" | "denied" = "pending";
   let decidedBy: string | null = null;
+  let decidedByType: "policy" | "budget_limiter" = "policy";
   let decidedAt: Date | null = null;
   let decisionReason: string | null = null;
 
-  if (overrideMatch) {
+  if (budgetReason) {
+    status = "denied";
+    decidedBy = "budget";
+    decidedByType = "budget_limiter";
+    decidedAt = now;
+    decisionReason = budgetReason;
+  } else if (overrideMatch) {
     // Override forces require_approval → stays pending (route to human)
     status = "pending";
     decisionReason = `Override active: ${overrideMatch.reason || "dynamic override"}`;
@@ -356,8 +377,8 @@ requestsRouter.post("/", async (c) => {
       requestId: id,
       action,
       status,
-      decidedBy: "policy",
-      decidedByType: "policy",
+      decidedBy: decidedBy ?? "policy",
+      decidedByType,
       decisionReason,
       requestSnapshot: {
         id, action, params, context, status, urgency,


### PR DESCRIPTION
## Per-agent budget enforcement (#13) — the payoff slice

Completes per-agent budgets end-to-end: when `AGENT_BUDGET_ENFORCEMENT` is on (**default off — ships dark**), a request from a **verified** agent over its monthly USD cap is **denied**, using the AgentLens-priced spend reader (AG-PR4, #20).

### What's in
- **schema** — `agents.monthlyBudgetUsd` (nullable; `null` = no budget), both dialects + migrations `0010`/`0007` (additive ALTERs).
- **`lib/agent-budget`** — `checkAgentBudget(agentId, tenantId)` compares current-month spend to the cap. A **soft guardrail**: gates the *next* request, can't stop in-flight spend, ~30s cache-stale — and **fails open** (an AgentLens outage or unconfigured AgentLens never blocks requests).
- **`requests` route** — budget check after the verified `effectiveAgentId` resolves; over budget → **denied, taking precedence over override/policy**, through the existing auto-decision path (audit + `request.denied` event + dispatch), attributed to a new `decidedByType: "budget_limiter"`.
- **admin** — optional `monthlyBudgetUsd` on agent create + `PATCH /api/agents/:id/budget`. `lib/agents`: `getAgentBudget` / `setAgentBudget`.
- **config** — `AGENT_BUDGET_ENFORCEMENT` flag.
- **core** — `RequestDecidedEvent.decidedByType` widened to include `budget_limiter` (string-rendered in adapters; no exhaustive switch breaks).

### Decision precedence
**budget deny > override (human review) > policy auto-decide.** Extracted into a pure `decideInitialStatus()` — the exact logic the route runs — so the precedence is unit-tested directly.

### Reviewed
27-agent adversarial review (enforcement correctness, fail-open + the cross-package union, schema/admin/tests): **no code defect, 0 fix-now**. Verifiers confirmed the precedence, the fail-open paths (no throw escapes `checkAgentBudget`, no 500/block), the flag-gate (fully inert when off), and the union widening are all correct. Its one real point — the route-level precedence wasn't tested (and the integration harness reimplements the route, so a mounted test wouldn't exercise real code) — is closed by the `decideInitialStatus` extraction + its precedence tests (second commit).

### Tests
+14 (`checkAgentBudget`: under/at/over-limit, no-budget, fail-open on unconfigured + on fetch error; `getAgentBudget`/`setAgentBudget`; `PATCH` 200/404; **`decideInitialStatus` precedence** — budget beats auto_approve and an active override). `monthly_budget_usd` backported to the 5 hardcoded agents test schemas. core 98 + server 679 green (the one failure is the env-dependent Redis-fallback test); clean recursive build; typecheck + lint clean.

Closes per-agent budgets (#13) across agentlens + agentgate.
