### PR TITLE
feat(server): per-agent budget alerts at 80%/100% (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,3 +111,16 @@ DASHBOARD_URL=
 # JSON array of routing rules. Example:
 # CHANNEL_ROUTES='[{"channel":"slack","target":"#alerts","enabled":true}]'
 CHANNEL_ROUTES=[]
+
+# -----------------------------------------------------------------------------
+# Per-agent budgets (optional, reads spend from AgentLens)
+# -----------------------------------------------------------------------------
+# AgentLens base URL + shared service token — source of per-agent priced spend.
+AGENTLENS_URL=
+AGENTGATE_SERVICE_TOKEN=
+# Deny requests from agents over their monthly cap (hard guardrail). Default off.
+AGENT_BUDGET_ENFORCEMENT=false
+# Emit 80%/100% near-limit notifications via the dispatcher (warn without
+# denying). Independent of enforcement. Routes like any other event — e.g. a
+# CHANNEL_ROUTES rule with "eventTypes":["budget.threshold"]. Default off.
+AGENT_BUDGET_ALERTS=false

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -36,6 +36,9 @@ export const EventNames = {
   API_KEY_REVOKED: "api_key.revoked",
   API_KEY_RATE_LIMITED: "api_key.rate_limited",
 
+  // Budget events
+  BUDGET_THRESHOLD: "budget.threshold",
+
   // System events
   SYSTEM_STARTUP: "system.startup",
   SYSTEM_SHUTDOWN: "system.shutdown",
@@ -224,6 +227,30 @@ export interface ApiKeyRateLimitedEvent
 }
 
 // ============================================================================
+// Budget Events
+// ============================================================================
+
+/**
+ * Emitted when an agent's current-month spend crosses a budget utilization
+ * threshold (e.g. 0.8 = near-limit warning, 1.0 = exceeded). A near-limit
+ * notification hook — does NOT by itself block the request (enforcement is
+ * separate). Fires once per (agent, month, threshold).
+ */
+export interface BudgetThresholdEvent
+  extends BaseEvent<typeof EventNames.BUDGET_THRESHOLD> {
+  payload: {
+    agentId: string;
+    tenantId: string;
+    /** The crossed threshold as a fraction of the cap (e.g. 0.8, 1.0). */
+    threshold: number;
+    /** spentUsd / limitUsd at evaluation time. */
+    utilization: number;
+    spentUsd: number;
+    limitUsd: number;
+  };
+}
+
+// ============================================================================
 // Union Type
 // ============================================================================
 
@@ -239,7 +266,8 @@ export type AgentGateEvent =
   | PolicyMatchedEvent
   | WebhookTriggeredEvent
   | WebhookFailedEvent
-  | ApiKeyRateLimitedEvent;
+  | ApiKeyRateLimitedEvent
+  | BudgetThresholdEvent;
 
 // ============================================================================
 // Helper Functions

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export {
   type WebhookTriggeredEvent,
   type WebhookFailedEvent,
   type ApiKeyRateLimitedEvent,
+  type BudgetThresholdEvent,
   type AgentGateEvent,
   createBaseEvent,
   eventMatchesFilter,

--- a/packages/server/src/__tests__/budget-alerts.test.ts
+++ b/packages/server/src/__tests__/budget-alerts.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-agent budget threshold alerts (#13 near-limit hook) —
+ * maybeAlertBudgetThreshold dedup + band selection.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventNames } from "@agentgate/core";
+import type { BudgetVerdict } from "../lib/agent-budget.js";
+import { maybeAlertBudgetThreshold, resetBudgetAlerts } from "../lib/budget-alerts.js";
+import { getGlobalDispatcher } from "../lib/notification/index.js";
+
+const verdict = (spentUsd: number, limitUsd: number | null): BudgetVerdict => ({
+  allowed: limitUsd === null || spentUsd < limitUsd,
+  limitUsd,
+  spentUsd,
+});
+
+let dispatch: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetBudgetAlerts();
+  // dispatchSync is fire-and-forget — stub it so no real channels are touched.
+  dispatch = vi.spyOn(getGlobalDispatcher(), "dispatchSync").mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+/** The single event the most recent dispatch call carried. */
+function lastEvent() {
+  return dispatch.mock.calls.at(-1)?.[0] as { type: string; payload: { threshold: number } };
+}
+
+describe("maybeAlertBudgetThreshold", () => {
+  it("no-ops for an agent with no budget", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(999, null), "default");
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("no-ops below the lowest threshold", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(70, 100), "default"); // 70%
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("fires a budget.threshold event at 80%", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "default");
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const ev = lastEvent();
+    expect(ev.type).toBe(EventNames.BUDGET_THRESHOLD);
+    expect(ev.payload).toMatchObject({ agentId: "agt_a", threshold: 0.8, spentUsd: 85, limitUsd: 100 });
+  });
+
+  it("dedups: the same band does not re-fire within a month", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "default");
+    maybeAlertBudgetThreshold("agt_a", verdict(90, 100), "default");
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("escalates to the 100% band once even after the 80% alert", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "default"); // 0.8
+    maybeAlertBudgetThreshold("agt_a", verdict(120, 100), "default"); // 1.0
+    maybeAlertBudgetThreshold("agt_a", verdict(130, 100), "default"); // dedup
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(lastEvent().payload.threshold).toBe(1.0);
+  });
+
+  it("reports only the highest crossed band on a single jump", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(150, 100), "default"); // straight to 150%
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(lastEvent().payload.threshold).toBe(1.0);
+  });
+
+  it("tracks agents independently", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "default");
+    maybeAlertBudgetThreshold("agt_b", verdict(85, 100), "default");
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("tracks the same agent independently across tenants", () => {
+    // Same agent id, two tenants with independent spend — both must alert.
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "tenant-1");
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "tenant-2");
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires at exactly the threshold boundary (>=)", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(80, 100), "default"); // exactly 80%
+    maybeAlertBudgetThreshold("agt_b", verdict(100, 100), "default"); // exactly 100%
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch.mock.calls[0]?.[0]).toMatchObject({ payload: { threshold: 0.8 } });
+    expect(dispatch.mock.calls[1]?.[0]).toMatchObject({ payload: { threshold: 1.0 } });
+  });
+
+  it("does not fire on a brand-new agent with zero spend", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(0, 100), "default");
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("re-arms when the calendar month rolls over", () => {
+    const jan = new Date(Date.UTC(2026, 0, 15));
+    const feb = new Date(Date.UTC(2026, 1, 15));
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "default", jan);
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "default", jan); // dedup
+    maybeAlertBudgetThreshold("agt_a", verdict(85, 100), "default", feb); // new month → fires
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a non-positive cap without dividing by zero", () => {
+    maybeAlertBudgetThreshold("agt_a", verdict(10, 0), "default"); // zero cap
+    maybeAlertBudgetThreshold("agt_b", verdict(10, -5), "default"); // negative cap
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -228,6 +228,12 @@ export const ConfigSchema = z.object({
     .union([z.boolean(), z.string()])
     .transform((val) => (typeof val === "boolean" ? val : ["true", "1", "yes"].includes(val.toLowerCase())))
     .default(false),
+  /** Emit near-limit budget notifications (80%/100% of cap) via the dispatcher.
+   *  Independent of enforcement — warn without denying. Default off. */
+  agentBudgetAlerts: z
+    .union([z.boolean(), z.string()])
+    .transform((val) => (typeof val === "boolean" ? val : ["true", "1", "yes"].includes(val.toLowerCase())))
+    .default(false),
 
   // Metrics
   /** Enable Prometheus metrics endpoint (default true) */
@@ -314,6 +320,7 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   AGENTLENS_URL: "agentlensUrl",
   AGENTGATE_SERVICE_TOKEN: "agentgateServiceToken",
   AGENT_BUDGET_ENFORCEMENT: "agentBudgetEnforcement",
+  AGENT_BUDGET_ALERTS: "agentBudgetAlerts",
 };
 
 // ============================================================================

--- a/packages/server/src/lib/budget-alerts.ts
+++ b/packages/server/src/lib/budget-alerts.ts
@@ -1,0 +1,77 @@
+// @agentgate/server — Per-agent budget threshold alerts (#13 near-limit hook).
+//
+// Fires a notification when an agent's current-month spend crosses a utilization
+// threshold (80% = near-limit warning, 100% = exceeded). Decoupled from hard
+// enforcement: an operator can get near-limit alerts via AGENT_BUDGET_ALERTS
+// without flipping on AGENT_BUDGET_ENFORCEMENT. Dedup is per (agent, month,
+// threshold) so an agent sitting over a threshold is notified once, not on every
+// request. Reads spend from the same BudgetVerdict the enforcement path computes,
+// so it fails closed-to-quiet on a telemetry outage (verdict reports 0 spend).
+
+import { EventNames, createBaseEvent, type BudgetThresholdEvent } from "@agentgate/core";
+import type { BudgetVerdict } from "./agent-budget.js";
+import { getGlobalDispatcher } from "./notification/index.js";
+
+// ponytail: 80%/100% hardcoded — the roadmap's two bands. Add an
+// AGENT_BUDGET_ALERT_THRESHOLDS env var if anyone needs custom bands.
+const THRESHOLDS = [0.8, 1.0] as const;
+
+// Dedup state for the CURRENT month only; cleared when the UTC month rolls over
+// (spend resets then too — see currentMonthWindow in agent-spend), which bounds
+// it to ~2 entries per active agent.
+// ponytail: in-memory, per-instance. Not shared across replicas and reset on
+// restart → an alert may re-fire after a deploy or fire once per replica. Fine
+// for a soft notification; persist to a table if exactly-once across the fleet
+// matters.
+let alerted = new Set<string>();
+let alertedPeriod = "";
+
+function currentPeriod(now: Date): string {
+  return `${now.getUTCFullYear()}-${now.getUTCMonth()}`;
+}
+
+/** @internal Reset dedup state — testing only. */
+export function resetBudgetAlerts(): void {
+  alerted = new Set();
+  alertedPeriod = "";
+}
+
+/**
+ * Emit a `budget.threshold` notification if `verdict` shows the agent newly
+ * crossed the highest configured threshold this month. No-op when the agent has
+ * no budget, hasn't crossed a threshold, or already alerted for that threshold.
+ * Fire-and-forget (uses the dispatcher's own fail-silently delivery).
+ */
+export function maybeAlertBudgetThreshold(
+  agentId: string,
+  verdict: BudgetVerdict,
+  tenantId: string,
+  now = new Date(),
+): void {
+  const { limitUsd, spentUsd } = verdict;
+  if (limitUsd === null || limitUsd <= 0) return;
+
+  const utilization = spentUsd / limitUsd;
+  // Highest crossed band — a jump from 0 to 150% alerts "exceeded", not "near".
+  let crossed: number | null = null;
+  for (const t of THRESHOLDS) if (utilization >= t) crossed = t;
+  if (crossed === null) return;
+
+  const period = currentPeriod(now);
+  if (period !== alertedPeriod) {
+    alerted = new Set();
+    alertedPeriod = period;
+  }
+  // Key on tenant too: spend is summed per tenant (see fetchAgentSpend), and the
+  // same agent id can serve multiple tenants with independent caps — keying on
+  // agentId alone would let one tenant's alert suppress another's.
+  const key = `${tenantId}:${agentId}:${crossed}`;
+  if (alerted.has(key)) return;
+  alerted.add(key);
+
+  const event: BudgetThresholdEvent = {
+    ...createBaseEvent(EventNames.BUDGET_THRESHOLD, "server"),
+    payload: { agentId, tenantId, threshold: crossed, utilization, spentUsd, limitUsd },
+  };
+  getGlobalDispatcher().dispatchSync(event);
+}

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -18,6 +18,7 @@ import { logAuditEvent } from "../lib/audit.js";
 import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
 import { resolveVerifiedAgentId, resolveEffectiveAgentId } from "../lib/agent-tokens.js";
 import { checkAgentBudget } from "../lib/agent-budget.js";
+import { maybeAlertBudgetThreshold } from "../lib/budget-alerts.js";
 import { decideInitialStatus } from "../lib/request-decision.js";
 import { getConfig } from "../config.js";
 import type { ApiKey } from "../db/schema.js";
@@ -256,15 +257,22 @@ requestsRouter.post("/", async (c) => {
   }
   const effectiveAgentId = resolved.agentId;
 
-  // Per-agent budget (issue #13): if enforcement is on and the verified agent is
-  // over its monthly cap, deny outright — this takes precedence over override /
-  // policy. Fail-open (checkAgentBudget never throws on a telemetry outage).
+  // Per-agent budget (issue #13). One spend read drives two opt-in features:
+  //  - enforcement: deny outright when over cap (precedence over override/policy);
+  //  - alerts: fire an 80%/100% near-limit notification (warn without denying).
+  // Fail-open (checkAgentBudget never throws on a telemetry outage).
+  const cfg = getConfig();
   let budgetReason: string | null = null;
-  if (getConfig().agentBudgetEnforcement && effectiveAgentId) {
+  if (effectiveAgentId && (cfg.agentBudgetEnforcement || cfg.agentBudgetAlerts)) {
     const tenantId = c.get("auth")?.tenantId ?? "default";
     const budget = await checkAgentBudget(effectiveAgentId, tenantId);
-    if (!budget.allowed) {
+    if (cfg.agentBudgetEnforcement && !budget.allowed) {
       budgetReason = `Monthly budget exceeded: $${budget.spentUsd.toFixed(2)} of $${budget.limitUsd?.toFixed(2)} used`;
+    }
+    // Alert independently of the deny decision: crossing 100% should notify
+    // precisely when the agent is also being cut off.
+    if (cfg.agentBudgetAlerts) {
+      maybeAlertBudgetThreshold(effectiveAgentId, budget, tenantId);
     }
   }
 


### PR DESCRIPTION
Closes #25. Sub-item of #13 (per-agent budgets).

A **near-limit notification hook** on the per-agent budget path. When `AGENT_BUDGET_ALERTS` is on, a request from an agent whose current-month spend (read from AgentLens) crosses **80%** or **100%** of its monthly cap emits a `budget.threshold` event through the existing dispatcher — so operators are warned before/at the cap, not only after a hard denial.

## What
- **New `budget.threshold` core event** (`packages/core/src/events.ts`). Renders via the adapters' existing generic fallback — **no adapter changes**. Routes like any other event, e.g. a `CHANNEL_ROUTES` rule with `"eventTypes":["budget.threshold"]`, or the default Slack/Discord channel.
- **`lib/budget-alerts.ts`** — `maybeAlertBudgetThreshold` picks the highest crossed band, deduped per `(tenant, agent, calendar-month, threshold)` in-memory so an over-threshold agent is notified **once**, not on every request. Re-arms on UTC month rollover (matching the spend window). Synchronous, so the `has()/add()` dedup is atomic under the event loop.
- **Decoupled from enforcement** via the new `AGENT_BUDGET_ALERTS` flag (default off, mirrors `AGENT_BUDGET_ENFORCEMENT`): warn without denying. One spend read drives both features (`routes/requests.ts`); alerts fire even when enforcement denies — you want notice exactly when an agent is cut off.
- **Fails open/quiet** on a telemetry outage: the fail-open verdict reports 0 spend → 0% utilization → no false alert.
- Filled the previously-undocumented budget/AgentLens config block in `.env.example`.

## Tests
`packages/server/src/__tests__/budget-alerts.test.ts` (12 unit tests): threshold bands, dedup, month rollover re-arm, highest-band-on-jump, per-agent and **per-tenant** independence, exact-boundary (`>=`), zero spend, zero/negative cap. Full server suite green (the 1 pre-existing rate-limiter Redis-fallback flake is unrelated).

## Review
Ran a multi-agent adversarial review (find → independently verify). Folded in the one confirmed defect — the dedup key now includes `tenantId` (spend is summed per tenant; the same agent id can serve multiple tenants) — plus the cheap boundary/multi-tenant/zero-spend test gaps. Deliberately **skipped** a full-route integration harness: the existing integration `helpers.ts` is a mock reimplementation that doesn't exercise the real route, and the codebase's own pattern (see `decideInitialStatus` / `virtual-keys.test.ts`) is to extract decision logic into pure, unit-tested functions — which `maybeAlertBudgetThreshold` is. Wiring is type-checked.

## Deliberate shortcuts (ponytail-marked)
- 80%/100% hardcoded — add an `AGENT_BUDGET_ALERT_THRESHOLDS` env if custom bands are ever needed.
- In-memory, per-instance dedup — may re-fire once per replica/after a deploy; fine for a soft notification. Persist to a table if exactly-once across the fleet ever matters.