### PR TITLE
feat(server): tighten per-agent budget soft-cap staleness (#23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,11 @@ WEBHOOK_TIMEOUT_MS=5000
 # Maximum webhook retry attempts
 WEBHOOK_MAX_RETRIES=3
 
+# Timeout (ms) for ALL AgentLens spend reads (budget path + GET /agents/:id/spend).
+# Kept short so a slow AgentLens can't add tail latency to POST /api/requests;
+# raise it if AgentLens is far/slow and informational spend reads start to 502.
+SPEND_READ_TIMEOUT_MS=5000
+
 # -----------------------------------------------------------------------------
 # Logging
 # -----------------------------------------------------------------------------

--- a/packages/server/src/__tests__/agent-budget.test.ts
+++ b/packages/server/src/__tests__/agent-budget.test.ts
@@ -51,8 +51,22 @@ beforeEach(() => {
 });
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
   resetConfig();
 });
+
+/** Stub fetch to return a per-agent spend from a mutable cell, so a test can
+ *  change the upstream value between reads. */
+function mutableSpend(agentId: string, cell: { usd: number }) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ spend: [{ agentId, totalCostUsd: cell.usd, lastEventAt: null }] }),
+    }) as Response),
+  );
+}
 
 describe("checkAgentBudget", () => {
   it("allows an agent with no budget (limit null)", async () => {
@@ -78,6 +92,52 @@ describe("checkAgentBudget", () => {
     clearSpendCache();
     mockSpend({ [agent.id]: 100 }); // exactly at limit → denied (spent < limit is false)
     expect((await checkAgentBudget(agent.id, "default")).allowed).toBe(false);
+  });
+
+  it("force-refreshes a stale near-cap read before deciding (#23)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z")); // 30s-aligned cache bucket
+    const { agent } = await createAgent("ci", null, 100);
+    const cell = { usd: 85 }; // 85% — in the danger zone, under cap
+    mutableSpend(agent.id, cell);
+    expect((await checkAgentBudget(agent.id, "default")).allowed).toBe(true);
+
+    cell.usd = 120; // jumps over cap; cached 85 is now stale
+    vi.advanceTimersByTime(5000); // 5s: within the 30s cache, past the 2s near-cap budget
+    const v = await checkAgentBudget(agent.id, "default");
+    expect(v.spentUsd).toBe(120); // re-read fresh, not the stale 85
+    expect(v.allowed).toBe(false);
+  });
+
+  it("keeps serving cache when well under the cap (no near-cap refresh) (#23)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    const { agent } = await createAgent("ci", null, 100);
+    const cell = { usd: 40 }; // 40% — far from cap
+    mutableSpend(agent.id, cell);
+    expect((await checkAgentBudget(agent.id, "default")).spentUsd).toBe(40);
+
+    cell.usd = 200; // would deny IF we refreshed
+    vi.advanceTimersByTime(5000);
+    const v = await checkAgentBudget(agent.id, "default");
+    expect(v.spentUsd).toBe(40); // stale cache served — far-from-cap agents skip the refresh
+    expect(v.allowed).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1); // only the initial read
+  });
+
+  it("keeps a confirmed-over-cap verdict when the near-cap re-read fails (no fail-open) (#23)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    const { agent } = await createAgent("ci", null, 100);
+    mockSpend({ [agent.id]: 105 }); // over cap; warms the cache
+    expect((await checkAgentBudget(agent.id, "default")).allowed).toBe(false);
+
+    // 5s later the cache is stale (>2s near-cap budget); make the re-read error.
+    vi.advanceTimersByTime(5000);
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500, text: async () => "" }) as Response));
+    const v = await checkAgentBudget(agent.id, "default");
+    expect(v.spentUsd).toBe(105); // fell back to the first read's valid value...
+    expect(v.allowed).toBe(false); // ...and still DENIES — does not fail open
   });
 
   it("fails OPEN when AgentLens is unconfigured", async () => {

--- a/packages/server/src/__tests__/agent-spend.test.ts
+++ b/packages/server/src/__tests__/agent-spend.test.ts
@@ -67,6 +67,43 @@ describe("fetchAgentSpend", () => {
     await fetchAgentSpend(["agt_a"], "default");
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
+  it("times out the spend read at spendReadTimeoutMs", async () => {
+    setConfig(parseConfig({ ...CONFIGURED, spendReadTimeoutMs: 100 })); // min allowed
+    // Honor the AbortSignal so the request rejects when the timeout fires.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => new Promise((_resolve, reject) => {
+        const sig = init?.signal;
+        if (sig?.aborted) return reject(new Error("aborted"));
+        sig?.addEventListener("abort", () => reject(new Error("aborted")));
+      })),
+    );
+    await expect(fetchAgentSpend(["agt_a"], "default")).rejects.toThrow();
+  });
+
+  it("re-fetches when the cached entry is older than maxAgeMs", async () => {
+    expect(new Date("2026-06-15T12:00:00.000Z").getTime() % 30_000).toBe(0); // guard: bucket-aligned
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z")); // 30s-aligned → same cache bucket below
+    const fn = mockFetch({ spend: [{ agentId: "agt_a", totalCostUsd: 1, lastEventAt: null }] });
+    await fetchAgentSpend(["agt_a"], "default"); // fetch #1
+    vi.advanceTimersByTime(3000); // 3s later
+    await fetchAgentSpend(["agt_a"], "default", undefined, 2000); // 3s > 2s maxAge → fetch #2
+    expect(fn).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("reuses a cache entry younger than maxAgeMs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    const fn = mockFetch({ spend: [{ agentId: "agt_a", totalCostUsd: 1, lastEventAt: null }] });
+    await fetchAgentSpend(["agt_a"], "default"); // fetch #1
+    vi.advanceTimersByTime(1000); // 1s later
+    await fetchAgentSpend(["agt_a"], "default", undefined, 2000); // 1s < 2s maxAge → cached
+    expect(fn).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
 });
 
 describe("GET /api/agents/:id/spend", () => {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -222,6 +222,10 @@ export const ConfigSchema = z.object({
   agentlensUrl: z.string().optional(),
   /** Shared service token for AgentLens' POST /api/internal/spend. */
   agentgateServiceToken: z.string().optional(),
+  /** Timeout (ms) for ALL AgentLens spend reads (budget path + GET /:id/spend).
+   *  Kept short so a slow AgentLens can't add tail latency to POST /api/requests;
+   *  raise it if your AgentLens is far/slow and informational reads 502. */
+  spendReadTimeoutMs: z.coerce.number().int().min(100).default(5000),
   /** Enforce per-agent monthly budgets (deny over-budget requests). Default off
    *  so the feature ships dark until an operator opts in. */
   agentBudgetEnforcement: z
@@ -313,6 +317,7 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   JWT_REFRESH_TTL: "jwtRefreshTtl",
   AGENTLENS_URL: "agentlensUrl",
   AGENTGATE_SERVICE_TOKEN: "agentgateServiceToken",
+  SPEND_READ_TIMEOUT_MS: "spendReadTimeoutMs",
   AGENT_BUDGET_ENFORCEMENT: "agentBudgetEnforcement",
 };
 

--- a/packages/server/src/lib/agent-budget.ts
+++ b/packages/server/src/lib/agent-budget.ts
@@ -9,8 +9,14 @@
 // is allowed, never blocked on a telemetry outage.
 
 import { getAgentBudget } from "./agents.js";
-import { fetchAgentSpend, SpendNotConfiguredError } from "./agent-spend.js";
+import { fetchAgentSpend, currentMonthWindow, SpendNotConfiguredError } from "./agent-spend.js";
 import { getLogger } from "./logger.js";
+
+// Near the cap the 30s-cached spend is too stale to gate on, so re-read with a
+// tight freshness budget. ponytail: 0.8 / 2s hardcoded — the issue's "> 80%"
+// band; make them config if an operator needs to tune the soft-cap tightness.
+const NEAR_CAP_FRACTION = 0.8;
+const NEAR_CAP_MAX_AGE_MS = 2000;
 
 export interface BudgetVerdict {
   allowed: boolean;
@@ -28,9 +34,13 @@ export async function checkAgentBudget(agentId: string, tenantId: string): Promi
   const limitUsd = await getAgentBudget(agentId);
   if (limitUsd === null) return { allowed: true, limitUsd: null, spentUsd: 0 };
 
+  // Pin one window for both reads so they share a cache key (the key buckets the
+  // window end into 30s slots — recomputing per read could straddle a boundary).
+  const window = currentMonthWindow();
+
   let spentUsd = 0;
   try {
-    spentUsd = (await fetchAgentSpend([agentId], tenantId)).get(agentId) ?? 0;
+    spentUsd = (await fetchAgentSpend([agentId], tenantId, window)).get(agentId) ?? 0;
   } catch (err) {
     // Fail open: a budget guardrail must never block requests because the
     // telemetry source is down or unconfigured.
@@ -38,6 +48,20 @@ export async function checkAgentBudget(agentId: string, tenantId: string): Promi
       getLogger().warn({ err, agentId }, "agent budget check failed; allowing (fail-open)");
     }
     return { allowed: true, limitUsd, spentUsd: 0 };
+  }
+
+  // Near the cap, re-read with a tight freshness budget so the gate sees current
+  // spend, not up-to-30s-stale spend (the main staleness-tightening — a stale
+  // cached value from a PRIOR request gets refreshed here). The small maxAge also
+  // reuses a just-written entry, so a cold read isn't fetched twice. A failure on
+  // THIS read keeps the first read's value (already valid) rather than failing
+  // open — we only fail open when telemetry is unreachable (the catch above).
+  if (spentUsd >= limitUsd * NEAR_CAP_FRACTION) {
+    try {
+      spentUsd = (await fetchAgentSpend([agentId], tenantId, window, NEAR_CAP_MAX_AGE_MS)).get(agentId) ?? spentUsd;
+    } catch (err) {
+      getLogger().warn({ err, agentId }, "near-cap spend re-read failed; using cached spend");
+    }
   }
 
   return { allowed: spentUsd < limitUsd, limitUsd, spentUsd };

--- a/packages/server/src/lib/agent-spend.ts
+++ b/packages/server/src/lib/agent-spend.ts
@@ -53,13 +53,16 @@ function toSpendMap(rows: SpendRow[], agentIds: string[]): Map<string, number> {
 /**
  * Fetch per-agent USD spend over a window (default: current month), keyed on the
  * verified agent ids. Returns a map agentId → spend (0 for agents with none).
- * Cached for {@link CACHE_TTL_MS}. Throws SpendNotConfiguredError when AgentLens
- * isn't configured; propagates upstream/network errors to the caller.
+ * Served from cache when an entry is younger than `maxAgeMs` (default
+ * {@link CACHE_TTL_MS}); pass a smaller value to bound staleness near a budget
+ * cap. Throws SpendNotConfiguredError when AgentLens isn't configured;
+ * propagates upstream/network errors to the caller.
  */
 export async function fetchAgentSpend(
   agentIds: string[],
   tenantId: string,
   window?: SpendWindow,
+  maxAgeMs = CACHE_TTL_MS,
 ): Promise<Map<string, number>> {
   const config = getConfig();
   if (!config.agentlensUrl || !config.agentgateServiceToken) {
@@ -75,11 +78,15 @@ export async function fetchAgentSpend(
   const key = `${tenantId}|${w.from}|${toBucket}|${[...agentIds].sort().join(",")}`;
   const now = Date.now();
   const hit = cache.get(key);
-  if (hit && now - hit.at < CACHE_TTL_MS) {
+  if (hit && now - hit.at < maxAgeMs) {
     return toSpendMap(hit.rows, agentIds);
   }
 
-  const client = new AgentGateHttpClient(config.agentlensUrl, config.agentgateServiceToken);
+  const client = new AgentGateHttpClient(
+    config.agentlensUrl,
+    config.agentgateServiceToken,
+    config.spendReadTimeoutMs,
+  );
   const res = await client.request<{ spend: SpendRow[] }>("POST", "/api/internal/spend", {
     agentIds,
     tenantId,

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -48,6 +48,7 @@ router.get("/:id/spend", async (c) => {
   const tenantId = c.get("auth")?.tenantId ?? "default";
   const window = currentMonthWindow();
   try {
+    // Informational read — default cache freshness (no near-cap tightening).
     const spend = await fetchAgentSpend([id], tenantId, window);
     return c.json({
       agentId: id,


### PR DESCRIPTION
Closes #23. Hardening on top of per-agent budgets (#21).

Per-agent budget enforcement is a deliberately **soft** guardrail: spend is read from AgentLens and cached 30s, so an agent could overshoot by up to ~30s, and the hot-path read inherited the shared HTTP client's 30s timeout. This tightens both.

## What
- **`fetchAgentSpend` gains a `maxAgeMs` param** (default = `CACHE_TTL_MS` 30s) — the cache-hit gate honors it; pass a smaller value to bound staleness.
- **Near-cap force-refresh** (`checkAgentBudget`): when spend ≥ 80% of the cap, re-read with a **2s** freshness budget so the allow/deny gate sees current spend, not up-to-30s-stale spend. The main benefit is across requests — a stale cached value from a prior request gets refreshed at the cap. Both reads share **one pinned window** → one cache key (no 30s-bucket straddle), and a just-written entry is reused so a cold read isn't fetched twice.
- **Shorter spend-read timeout**: new `SPEND_READ_TIMEOUT_MS` config (default **5s**, min 100) passed to the spend HTTP client, so a slow AgentLens can't add ~30s tail latency to `POST /api/requests`. Applies to all spend reads (budget path + `GET /agents/:id/spend`); raise it if AgentLens is far/slow.

## Adversarial review — fixed a fail-open regression
A multi-agent review (find → verify) caught a **high-severity** bug in the first cut: the near-cap re-read shared the outer `try/catch`, so a *re-read* timeout on a **confirmed-over-cap** agent would fail open and **allow** it — worse than the prior single-read behavior. Fixed: the near-cap re-read now has its **own** `try/catch` that degrades to the first read's valid value and still **denies**; we fail open only when telemetry is truly unreachable (the first read throws). Also pinned the shared window (review's bucket-boundary finding) and added a timeout-applied test + the over-cap-deny-on-re-read-failure test.

## Tests
`agent-spend.test.ts` (+maxAgeMs refresh/reuse, timeout-applied) and `agent-budget.test.ts` (+near-cap refresh, far-from-cap no-refresh, **over-cap deny when re-read fails**). Full server suite green (the 1 pre-existing rate-limiter Redis-fallback flake is unrelated).

## Deliberate skips (ponytail)
- **Coalescing** concurrent cache-misses (the issue's optional 3rd item) — `POST /api/requests` is low-frequency human-in-the-loop with enforcement default-off; not worth the in-flight-promise machinery.
- **Full-route integration test** for enforcement — the integration `helpers.ts` is a mock reimplementation that doesn't mount the real route; the repo pattern is extract-pure + unit-test (`decideInitialStatus`, `checkAgentBudget`), which this follows.
- 0.8 / 2s hardcoded — `ponytail:` comment marks the config upgrade path.