### PR TITLE
feat(identity): close the agent-identity spine foundation (#12 Phase 1)

### DIFF
--- a/.changeset/agent-identity-phase1-close.md
+++ b/.changeset/agent-identity-phase1-close.md
@@ -1,0 +1,9 @@
+---
+"@agentgate/server": patch
+---
+
+Close out the agent-identity spine (#12) foundation: add the formal identity spec, a verified-identity check on the reactive-guardrails webhook, and real-route end-to-end tests.
+
+- **docs/agent-identity.md** — reference spec for the model as built: credential types (`agt_*`/`ags_*` + short-lived `typ:"agent"` JWT), the OAuth2 client-credentials token flow, resolution order (token > virtual-key binding > legacy headers), use-time liveness/revocation, the HS256 shared-secret trust boundary and its limits, and the downstream-propagation contract for AgentLens (verify + stamp into event metadata, not the hash) and Lore (principal binding).
+- **Guardrails webhook** — `POST /api/guardrails/webhook` now only creates an override on breach when the reported `agentId` resolves to a registered, active agent (`getAgentIfActive`); breaches for unknown or revoked agents are ignored. This avoids creating override rows that were already inert for such agents (override matching keys on the *verified* agent id, which an unverified/unknown agent never obtains). The registry lookup **fails open**: on a transient DB error the override is still applied, so a breach is never silently dropped during an outage.
+- **E2E tests** (`agent-identity-e2e.test.ts`) — drive the real routes against a real in-memory DB: OAuth2 token → `POST /api/requests` → verified id persisted on the approval request and stamped into the audit trail; plus the negative paths (forged user token, revoked agent, expired token) all rejected.

--- a/docs/agent-identity.md
+++ b/docs/agent-identity.md
@@ -1,0 +1,199 @@
+# Agent Identity
+
+AgentGate binds a **verifiable agent identity** to the actions an autonomous
+agent takes, so that guardrail decisions, approval requests, and (downstream)
+observability traces and memory writes are all attributable to a specific,
+revocable principal — not to an unauthenticated, caller-supplied string.
+
+This document is the reference spec for that identity model: the credential
+types, how a token is minted and verified, where the verified id is stamped,
+the trust boundary and its limits, and the contract downstream services
+(AgentLens, Lore) use to consume the identity.
+
+> Status: the AgentGate core spine is implemented (issue #12). SPIFFE/WIMSE and
+> asymmetric (JWKS) verification are explicit non-goals for now — see
+> [Future work](#future-work).
+
+## Why
+
+An agent calling AgentGate today can put *any* `agentId` in the request body.
+That claim is unauthenticated: a misconfigured or malicious agent can
+impersonate another, and an audit trail keyed on it proves nothing. The agent
+identity spine replaces that claim, on the paths that matter, with a
+cryptographically verified id resolved from a credential the agent actually
+holds.
+
+The verified id is deliberately kept **separate** from the unverified
+`context.agentId` claim — both can appear on a request; only the verified one
+is trusted for decisions and recorded as evidence.
+
+## Credential types
+
+| Credential | Format | Lifetime | Where used |
+|---|---|---|---|
+| **Agent registry secret** | `client_id` = `agt_…`, `client_secret` = `ags_…` | Long-lived (until revoked/rotated) | Exchanged once at the token endpoint; or sent directly as legacy headers |
+| **Agent access token** | Short-lived HS256 JWT, `typ:"agent"` | `jwtAccessTtl` (default 900s) | Presented as `X-Agent-Token` on each request |
+
+An agent is a row in the `agents` registry (`packages/server/src/db/schema.*`):
+`id` (`agt_…`), `name`, `secretHash` (SHA-256 of the `ags_…` secret),
+`status` (`active` | `revoked`), `revokedAt`, optional `monthlyBudgetUsd`. The
+plaintext secret is shown once at creation and never stored.
+
+### OAuth2 client-credentials grant
+
+`POST /api/agents/token` implements the OAuth2 `client_credentials` grant
+(`packages/server/src/routes/agent-tokens.ts`). The agent presents its
+`agt_…` / `ags_…` pair as a JSON body or HTTP Basic credentials:
+
+```http
+POST /api/agents/token
+Content-Type: application/json
+
+{ "grant_type": "client_credentials", "client_id": "agt_…", "client_secret": "ags_…" }
+```
+
+```json
+{ "access_token": "<jwt>", "token_type": "Bearer", "expires_in": 900 }
+```
+
+The returned JWT carries `{ sub: <agt_id>, typ: "agent", iat, exp, … }` and is
+signed with the server's shared `JWT_SECRET` (HS256). The `typ:"agent"` claim
+is **load-bearing**: it is the sole discriminator that prevents a user session
+token (same signer) from being accepted on an agent path, and vice versa. The
+token endpoint returns `400` in `api-key-only` auth mode (no real JWT secret is
+configured there, so a token would be forgeable).
+
+The agent then sends the token instead of its long-lived secret:
+
+```http
+POST /api/requests
+X-Agent-Token: <jwt>
+```
+
+## Verification & resolution order
+
+`resolveVerifiedAgentId()` (`packages/server/src/lib/agent-tokens.ts`) resolves
+the verified id for an inbound request, preferring the strongest credential:
+
+1. **`X-Agent-Token`** (preferred) — verify the JWT signature **and**
+   `typ:"agent"`; then **re-check liveness at use time** via
+   `getAgentIfActive()` (a stateless token can outlive a revoke). Disabled in
+   `api-key-only` mode.
+2. **`X-Agent-Id` / `X-Agent-Secret`** (legacy fallback) — constant-time hash
+   comparison against the registry.
+3. Otherwise → `null` (no verified identity; the request proceeds *unverified*).
+
+On routes that also support **virtual keys** (an API key bound to an agent,
+issue #13), `resolveEffectiveAgentId()` reconciles the key binding with the
+separately verified id:
+
+- a key bound to an agent **is** that agent's credential → the binding is
+  authoritative and promotes to the verified id;
+- a request that *separately* verifies as a **different** agent → `403`
+  (conflict);
+- a binding to a **revoked/unknown** agent → `403` (the bound agent's liveness
+  is re-checked here too, because revoking an agent does not cascade to keys).
+
+## Where the verified id is stamped
+
+| Surface | Behavior |
+|---|---|
+| `POST /api/requests` | `approvalRequests.verifiedAgentId` is set to the effective verified id; the `created` audit entry records `verifiedAgentId`. Overrides and policies are scoped on it (resolved *before* policy evaluation). |
+| `POST /api/mcp/authorize` | The MCP tool-call gate keys on the verified id (an MCP server's virtual-key binding). |
+| `POST /api/guardrails/webhook` | A breach only creates an override when its `agentId` resolves to a **registered, active** agent (`getAgentIfActive`); breaches for unknown or revoked agents are ignored. The id is supplied by AgentLens over a shared-secret channel and is not a credential, so this registry check is the available "verified identity" guarantee on this path. |
+
+The audit log thus records **both** the human decision-maker (from the OIDC
+user context, on the decision endpoint) and the agent that made the request
+(from the verified credential) — the accountability pair regulated AI needs.
+
+## Revocation
+
+`revokeAgent(id)` sets `status='revoked'` + `revokedAt`. Because verification
+re-checks `getAgentIfActive()` at use time, a revoked agent is rejected
+immediately on its next call **even if a previously minted token is still
+within its TTL**. There is no separate token-revocation list; revoke the agent.
+
+## Trust model & limits
+
+- **Symmetric signing.** Agent tokens are HS256 over the shared `JWT_SECRET`.
+  Any service that holds that secret can both mint and verify agent tokens.
+  There is no `kid`, no `aud`, and no asymmetric/JWKS option today.
+- **Liveness is local.** Cryptographic verification proves the id; it does
+  **not** prove the agent is still active. Only AgentGate (which owns the
+  `agents` table) can answer liveness. A stateless verifier gets identity, not
+  revocation.
+- **`api-key-only` mode disables tokens** entirely (the dev-placeholder secret
+  would make them forgeable); the legacy header path is used instead.
+- **Rate limiting.** The token endpoint is not yet rate-limited per client;
+  treat a leaked `ags_…` secret as you would any credential and rotate by
+  re-creating the agent.
+
+## Downstream propagation (the consumer contract)
+
+The same verified identity is intended to flow to the rest of the platform.
+These are separate epics; this section is the contract they build against.
+
+### AgentLens (Phase 2 — verify & stamp on ingest)
+
+AgentLens events already carry an `agentId`, but it is **self-reported by the
+SDK**. To make the tamper-evident audit trail *attributable*, AgentLens
+verifies an AgentGate agent token at ingest and stamps the verified id.
+
+- **Verification:** AgentLens already depends on `agentkit-auth`; it verifies
+  the token with the **shared `JWT_SECRET`** and the `typ:"agent"` guard. (A
+  JWKS/asymmetric option would remove the shared-secret coupling — see
+  [Future work](#future-work).)
+- **Where it lands:** the verified id is written to event **metadata**
+  (e.g. `metadata.verifiedAgentId`, `verificationMethod`, `verifiedAt`), **not**
+  added to the hashed event fields. AgentLens events are SHA-256 hash-chained;
+  changing the hashed field set would invalidate every existing chain. Metadata
+  is covered by the chain as a whole, so this stays tamper-evident without a
+  hash-version migration.
+- **Liveness:** ingest performs cryptographic verification only; it does not
+  call back to AgentGate per event. Tokens are short-lived, which bounds the
+  staleness.
+
+### Lore (Phase 3 — principal binding)
+
+Lore already binds every memory to its writing principal
+(`AuthContext.principal_id`) and filters reads by it (private/shared
+visibility). Phase 3 is to **recognize an AgentGate agent token as a
+principal** (alongside API-key and OIDC principals) and, optionally, to tag the
+principal *type* (`user` | `agent` | `service`) for audit and recall semantics.
+The ownership-binding and visibility machinery already exist; this is a
+formalization, not a new subsystem.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `JWT_SECRET` | — (required when JWT/OIDC auth is enabled) | Shared HS256 secret used to sign **and** verify agent tokens. Must be ≥32 chars and not the dev placeholder. |
+| `JWT_SECRET_FILE` | — | File-based alternative to `JWT_SECRET`. |
+| `AUTH_MODE` | `dual` | `api-key-only` disables the agent-token path (legacy headers only). |
+| `jwtAccessTtl` | `900` (s) | Agent access-token lifetime. |
+| `GUARDRAILS_WEBHOOK_SECRET` | — | Shared secret authenticating the reactive-guardrails webhook. |
+
+## Security considerations
+
+- **Never log the `ags_…` secret or a minted token.** Treat both as bearer
+  credentials.
+- **Sharing `JWT_SECRET` across services** (for downstream verification) widens
+  the blast radius of a leak: a leaked secret lets an attacker mint agent
+  tokens accepted everywhere. Prefer a dedicated rotation process; the JWKS
+  path (future) removes this coupling.
+- **The unverified `context.agentId` is never trusted** for decisions; only the
+  resolved verified id is.
+- **Forgery is gated by the `typ:"agent"` check** plus signature; the e2e suite
+  asserts that a forged user token, an expired token, and a revoked agent's
+  token are all rejected (`packages/server/src/__tests__/agent-identity-e2e.test.ts`).
+
+## Future work
+
+- **Asymmetric signing / JWKS** (`RS256` + a published key set) so downstream
+  services verify without sharing `JWT_SECRET`, with `kid`-based rotation.
+- **`aud` scoping** so a token is only valid for its intended consumer.
+- **SPIFFE SVID / WIMSE** workload identity for mesh deployments
+  (X.509 / Workload API), resolving to the same verified principal.
+- **RFC-8693 token exchange** for delegated/on-behalf-of agent chains.
+- **Token-endpoint rate limiting** and a credential-rotation playbook
+  (dual-active secret window).

--- a/packages/server/src/__tests__/agent-identity-e2e.test.ts
+++ b/packages/server/src/__tests__/agent-identity-e2e.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Agent-identity spine end-to-end (#12).
+ *
+ * Drives the REAL routes against a REAL (in-memory, migrated) database — only
+ * getDb() is redirected — to prove the full OAuth2 client-credentials flow:
+ *   mint token (POST /api/agents/token) → present X-Agent-Token on
+ *   POST /api/requests → the verified agent id is persisted on the approval
+ *   request AND stamped into the audit trail.
+ * Plus the negative paths: a forged (user) token, a revoked agent, and an
+ * expired token must NOT be accepted as a verified agent identity.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { signAccessToken, type AuthConfig } from "agentkit-auth";
+import { createTestDb } from "./setup.js";
+
+const WRONG_SECRET = "a-totally-different-secret-32-chars-xx";
+
+const ctx = createTestDb();
+
+// Redirect every getDb() in the route chain at the real in-memory DB while
+// preserving the module's schema re-exports (routes import tables from here).
+vi.mock("../db/index.js", async () => {
+  const schema = await import("../db/schema.js");
+  return { ...schema, getDb: () => ctx.db };
+});
+
+import { createAgent, revokeAgent } from "../lib/agents.js";
+import * as agentsLib from "../lib/agents.js";
+import { approvalRequests, auditLogs, overrides } from "../db/schema.js";
+import agentTokenRouter from "../routes/agent-tokens.js";
+import requestsRouter from "../routes/requests.js";
+import { createGuardrailsRouter } from "../routes/guardrails.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+import { invalidatePolicyCache } from "../lib/policy-cache.js";
+
+const TEST_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+
+function jwtConfig(ttlSeconds = 900, secret = TEST_SECRET): AuthConfig {
+  return {
+    oidc: null,
+    jwt: { secret, accessTokenTtlSeconds: ttlSeconds, refreshTokenTtlSeconds: 604800 },
+    authDisabled: false,
+  };
+}
+
+/** Decode a JWT's payload without verifying it (test introspection only). */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(token.split(".")[1]!, "base64url").toString());
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.route("/api/agents/token", agentTokenRouter);
+  app.route("/api/requests", requestsRouter);
+  app.route(
+    "/api/guardrails",
+    createGuardrailsRouter({
+      secret: "wh-secret",
+      rules: [{ metric: "error_rate", toolPattern: "*", ttlSeconds: 3600 }],
+    }),
+  );
+  return app;
+}
+
+async function mintToken(app: Hono, clientId: string, secret: string): Promise<string> {
+  const res = await app.request("/api/agents/token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ grant_type: "client_credentials", client_id: clientId, client_secret: secret }),
+  });
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { access_token: string }).access_token;
+}
+
+async function createRequest(app: Hono, headers: Record<string, string>): Promise<string> {
+  const res = await app.request("/api/requests", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    // A deliberately different caller-claimed context.agentId proves the
+    // VERIFIED id is independent of the unauthenticated claim.
+    body: JSON.stringify({ action: "deploy_production", context: { agentId: "claimed-imposter" } }),
+  });
+  expect(res.status).toBe(201);
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function verifiedAgentIdOf(requestId: string): Promise<string | null> {
+  const rows = await ctx.db.select().from(approvalRequests).where(eq(approvalRequests.id, requestId));
+  return rows[0]?.verifiedAgentId ?? null;
+}
+
+beforeEach(() => {
+  // Children before parents (audit_logs FK → approval_requests).
+  ctx.sqlite.exec(
+    "DELETE FROM audit_logs; DELETE FROM approval_requests; DELETE FROM agents; DELETE FROM overrides; DELETE FROM policies;",
+  );
+  setConfig(parseConfig({ jwtSecret: TEST_SECRET })); // authMode defaults to "dual"
+  invalidatePolicyCache();
+});
+
+afterAll(() => {
+  resetConfig();
+  ctx.cleanup();
+});
+
+describe("agent-identity e2e: OAuth2 → approval → audit", () => {
+  it("stamps the verified agent id on the request AND the audit trail", async () => {
+    const app = makeApp();
+    const { agent, secret } = await createAgent("ci-agent");
+
+    const token = await mintToken(app, agent.id, secret);
+    const requestId = await createRequest(app, { "x-agent-token": token });
+
+    // Persisted on the approval request, not the caller's claimed id.
+    expect(await verifiedAgentIdOf(requestId)).toBe(agent.id);
+
+    // Stamped into the audit trail as cryptographic evidence of who made it.
+    const audit = await ctx.db.select().from(auditLogs).where(eq(auditLogs.requestId, requestId));
+    const created = audit.find((a) => a.eventType === "created");
+    expect(created).toBeDefined();
+    expect(JSON.parse(created!.details!).verifiedAgentId).toBe(agent.id);
+  });
+
+  it("rejects a forged user token (no typ:agent) even for a registered agent id", async () => {
+    const app = makeApp();
+    // The token's sub IS a real, active agent — so the ONLY thing that can
+    // reject it is the missing typ:"agent" claim (the cross-over guard), not
+    // the agent being absent from the registry.
+    const { agent } = await createAgent("crossover-agent");
+    const userToken = await signAccessToken(
+      { sub: agent.id, tid: "default", role: "admin", email: "a@x.io" },
+      jwtConfig(),
+    );
+    const requestId = await createRequest(app, { "x-agent-token": userToken });
+    expect(await verifiedAgentIdOf(requestId)).toBeNull();
+  });
+
+  it("rejects a token signed with the wrong key (signature is load-bearing)", async () => {
+    const app = makeApp();
+    // A real, active agent + a valid typ:"agent" claim, but signed with a key
+    // the server does not trust → only the signature check can reject it.
+    const { agent } = await createAgent("sig-agent");
+    const forged = await signAccessToken(
+      { sub: agent.id, tid: "default", role: "viewer", email: "", typ: "agent" },
+      jwtConfig(900, WRONG_SECRET),
+    );
+    const requestId = await createRequest(app, { "x-agent-token": forged });
+    expect(await verifiedAgentIdOf(requestId)).toBeNull();
+  });
+
+  it("rejects a revoked agent's still-signed token — no verified id stamped", async () => {
+    const app = makeApp();
+    const { agent, secret } = await createAgent("rev-agent");
+    const token = await mintToken(app, agent.id, secret);
+    await revokeAgent(agent.id); // token signature stays valid; use-time check rejects
+
+    const requestId = await createRequest(app, { "x-agent-token": token });
+    expect(await verifiedAgentIdOf(requestId)).toBeNull();
+  });
+
+  it("rejects an expired token — no verified id stamped", async () => {
+    const app = makeApp();
+    const { agent } = await createAgent("exp-agent");
+    // Negative TTL → exp in the past → verifyAccessToken returns null.
+    const expired = await signAccessToken(
+      { sub: agent.id, tid: "default", role: "viewer", email: "", typ: "agent" },
+      jwtConfig(-10),
+    );
+    // Confirm the token is genuinely expired (not merely malformed), so the
+    // rejection below is provably due to expiry.
+    expect(decodeJwtPayload(expired).exp as number).toBeLessThan(Math.floor(Date.now() / 1000));
+
+    const requestId = await createRequest(app, { "x-agent-token": expired });
+    expect(await verifiedAgentIdOf(requestId)).toBeNull();
+  });
+});
+
+describe("guardrails webhook identity (#12)", () => {
+  async function postBreach(app: Hono, agentId: string) {
+    return app.request("/api/guardrails/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-guardrails-secret": "wh-secret" },
+      body: JSON.stringify({ event: "breach", metric: "error_rate", agentId }),
+    });
+  }
+
+  it("creates an override for a known active agent but ignores an unknown one", async () => {
+    const app = makeApp();
+    const { agent } = await createAgent("monitored");
+
+    const ok = await postBreach(app, agent.id);
+    expect(ok.status).toBe(200);
+    expect(((await ok.json()) as { status: string }).status).toBe("override_created");
+    const rows = await ctx.db.select().from(overrides).where(eq(overrides.agentId, agent.id));
+    expect(rows).toHaveLength(1);
+
+    const ghost = await postBreach(app, "agt_ghost");
+    expect(ghost.status).toBe(200);
+    expect(((await ghost.json()) as { status: string }).status).toBe("ignored");
+    expect(await ctx.db.select().from(overrides).where(eq(overrides.agentId, "agt_ghost"))).toHaveLength(0);
+  });
+
+  it("ignores a breach for a revoked agent", async () => {
+    const app = makeApp();
+    const { agent } = await createAgent("revoked-monitored");
+    await revokeAgent(agent.id);
+    const res = await postBreach(app, agent.id);
+    expect(((await res.json()) as { status: string }).status).toBe("ignored");
+  });
+
+  it("fails OPEN and still applies the override if the registry lookup errors", async () => {
+    const app = makeApp();
+    const spy = vi.spyOn(agentsLib, "getAgentIfActive").mockRejectedValueOnce(new Error("db down"));
+    const res = await postBreach(app, "agt_during_outage");
+    expect(((await res.json()) as { status: string }).status).toBe("override_created");
+    spy.mockRestore();
+  });
+});

--- a/packages/server/src/routes/guardrails.ts
+++ b/packages/server/src/routes/guardrails.ts
@@ -14,6 +14,7 @@ import { Hono } from "hono";
 import { nanoid } from "nanoid";
 import { eq } from "drizzle-orm";
 import { getDb, overrides } from "../db/index.js";
+import { getAgentIfActive } from "../lib/agents.js";
 
 type Db = ReturnType<typeof getDb>;
 
@@ -166,6 +167,26 @@ export function createGuardrailsRouter(opts?: {
     if (!rule) return c.json({ status: "ignored", reason: "no matching rule" }, 200);
 
     if (body.event === "breach") {
+      // Agent-identity check (#12): body.agentId is supplied by AgentLens and is
+      // NOT cryptographically verified here, so only gate agents that resolve to
+      // a registered, active entry in the agent registry (the agentlens.agentId
+      // == agt_* join convention makes this the same id). This skips creating
+      // overrides for unknown or revoked agents. Recovery needs no such check —
+      // it only removes an override this process tracked.
+      //
+      // Fail OPEN on a registry-lookup error: a guardrail breach should still
+      // gate the agent during a transient DB error rather than 500 — the worst
+      // case is a stray override that is inert (checkOverrides keys on the
+      // VERIFIED agent id) and TTL-expires anyway.
+      let knownActive = true;
+      try {
+        knownActive = (await getAgentIfActive(body.agentId)) !== null;
+      } catch {
+        knownActive = true;
+      }
+      if (!knownActive) {
+        return c.json({ status: "ignored", reason: "unknown or revoked agent" }, 200);
+      }
       const id = await applyBreach(getDb(), rule, body.agentId, tracker);
       return c.json({ status: "override_created", overrideId: id }, 200);
     }


### PR DESCRIPTION
Closes the open **AgentGate-side** acceptance criteria for the agent-identity epic (#12). The core spine (registry, OAuth2 agent tokens, verified-id stamping) already shipped in #15–#18; this adds the three remaining in-repo pieces: the formal spec, verified identity on the guardrails webhook, and real-route e2e tests.

This is **Phase 1 (A)** of the "both, sequenced" plan. Phase B (AgentLens verifies + stamps `verifiedAgentId` on ingest — the cross-repo unification wedge) follows in a separate PR.

## What's here

- **`docs/agent-identity.md`** — reference spec for the model *as built*: credential types (`agt_*`/`ags_*` + short-lived `typ:"agent"` JWT), the OAuth2 client-credentials flow (`POST /api/agents/token`), resolution order (token > virtual-key binding > legacy headers), `api-key-only` gating, use-time liveness/revocation, the **HS256 shared-secret trust boundary and its limits**, and the **downstream-propagation contract** for AgentLens (verify + stamp into event *metadata*, not the hash — adding to the hashed fields would break every existing chain) and Lore (principal binding).
- **Guardrails webhook identity** — `POST /api/guardrails/webhook` now only creates an override on breach when the reported `agentId` resolves to a **registered, active** agent (`getAgentIfActive`); unknown/revoked agents are ignored. Those overrides were already *inert* for such agents (matching keys on the verified id). The lookup **fails open** on a transient DB error, so a breach is never silently dropped during an outage.
- **E2E tests** (`agent-identity-e2e.test.ts`) — drive the **real** routes against a real in-memory migrated DB (only `getDb()` is redirected): OAuth2 token → `POST /api/requests` → verified id **persisted on the approval request and stamped into the audit trail**.

## Forgery protection proven at every layer

The negative e2e cases are written so each isolates one check (the verified id ends up `null` for exactly one reason):

| Attack | Why it's rejected | Isolation |
|---|---|---|
| Wrong-key signature | signature check | real active agent + valid `typ:agent`, only the key is wrong |
| User token (no `typ:agent`) | cross-over guard | sub **is** a registered active agent, so only the missing `typ` rejects it |
| Expired token | `exp` validation | test decodes the token and asserts `exp` is genuinely in the past first |
| Revoked agent's valid token | use-time liveness recheck | token signature stays valid; revoke makes `getAgentIfActive` reject |

## Adversarial review

An 18-agent find→verify review hardened two real issues it caught: the guardrails breach path now **fails open** on a registry-lookup DB error (was an unguarded call that would 500), and the e2e suite was tightened so signature/`typ`/expiry checks are provably load-bearing rather than passing for incidental reasons. (Pre-existing, out-of-scope findings — `POST /api/overrides` not validating `agentId`, `applyRecovery` non-atomicity — are noted but not changed here.)

## Verification

- Full server suite: **710 passed**, typecheck clean. (The 1 failure is the pre-existing `rate-limiter.test.ts` Redis-fallback env flake on `main`, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)