### PR TITLE
feat(dashboard): per-agent governance dashboard (#22)

### DIFF
--- a/.changeset/governance-dashboard.md
+++ b/.changeset/governance-dashboard.md
@@ -1,0 +1,12 @@
+---
+"@agentgate/dashboard": minor
+"@agentgate/server": minor
+---
+
+Add a per-agent governance dashboard (#22).
+
+- **New Agents page** (`/agents`, `keys:manage`) — register/revoke agents and, per agent: set/clear the monthly budget with a live budget-vs-spend bar (current-month spend from AgentLens, gracefully shows "n/a" when spend telemetry isn't configured), the bound virtual keys, and the active tool overrides (add/remove `require_approval` / `deny` overrides with an optional TTL).
+- **Policies** — each policy now shows its `scope` (global / per_agent / per_tool) and the agent/tool ids it targets, plus a **"Clone to agents"** action that creates a per-agent-scoped copy across selected agents.
+- **Audit log** — new filters for **`verifiedAgentId`** (the cryptographically verified agent that made the request) and **`decidedByType`** (policy / human / agent / budget_limiter / override), surfaced inline in each entry. Server-side: `GET /api/audit` accepts `verifiedAgentId` (column filter via the request join) and `decidedByType` (matched in the decision event's details JSON, backend-agnostic via the active dialect).
+
+No new backend endpoints beyond the two audit filters — the dashboard composes the existing agents / api-keys / overrides / policies APIs.

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -9,6 +9,7 @@ import {
   RequestListSkeleton,
   AuditLogSkeleton,
   ApiKeysSkeleton,
+  AgentsSkeleton,
   WebhooksSkeleton,
   SkeletonBox,
 } from './components/Skeleton';
@@ -17,6 +18,7 @@ const Home = lazy(() => import('./pages/Home'));
 const RequestList = lazy(() => import('./pages/RequestList'));
 const RequestDetail = lazy(() => import('./pages/RequestDetail'));
 const ApiKeys = lazy(() => import('./pages/ApiKeys'));
+const Agents = lazy(() => import('./pages/Agents'));
 const Webhooks = lazy(() => import('./pages/Webhooks'));
 const AuditLog = lazy(() => import('./pages/AuditLog'));
 const Policies = lazy(() => import('./pages/Policies'));
@@ -149,6 +151,7 @@ function App() {
               <NavLink to="/simulator">Simulator</NavLink>
               <NavLink to="/audit">Audit Log</NavLink>
               <NavLink to="/analytics">Analytics</NavLink>
+              {canManageKeys && <NavLink to="/agents">Agents</NavLink>}
               {canManageKeys && <NavLink to="/settings/api-keys">API Keys</NavLink>}
               {canManageWebhooks && <NavLink to="/settings/webhooks">Webhooks</NavLink>}
               {canManageWebhooks && <NavLink to="/webhooks/observability">Webhook Health</NavLink>}
@@ -209,6 +212,7 @@ function App() {
               <NavLink to="/simulator" onClick={closeMobileMenu}>Simulator</NavLink>
               <NavLink to="/audit" onClick={closeMobileMenu}>Audit Log</NavLink>
               <NavLink to="/analytics" onClick={closeMobileMenu}>Analytics</NavLink>
+              {canManageKeys && <NavLink to="/agents" onClick={closeMobileMenu}>Agents</NavLink>}
               {canManageKeys && <NavLink to="/settings/api-keys" onClick={closeMobileMenu}>API Keys</NavLink>}
               {canManageWebhooks && <NavLink to="/settings/webhooks" onClick={closeMobileMenu}>Webhooks</NavLink>}
               {canManageWebhooks && <NavLink to="/webhooks/observability" onClick={closeMobileMenu}>Webhook Health</NavLink>}
@@ -318,6 +322,18 @@ function App() {
                 <Suspense fallback={<div className="space-y-6"><SkeletonBox className="h-8 w-48" /><div className="grid grid-cols-2 sm:grid-cols-4 gap-4"><SkeletonBox className="h-24" /><SkeletonBox className="h-24" /><SkeletonBox className="h-24" /><SkeletonBox className="h-24" /></div></div>}>
                   <Analytics />
                 </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/agents"
+            element={
+              <ProtectedRoute>
+                <PermissionRoute permission="keys:manage">
+                  <Suspense fallback={<AgentsSkeleton />}>
+                    <Agents />
+                  </Suspense>
+                </PermissionRoute>
               </ProtectedRoute>
             }
           />

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -65,6 +65,8 @@ export interface PolicyTemplate {
   priority: number;
 }
 
+export type PolicyScope = 'global' | 'per_agent' | 'per_tool';
+
 export interface ListPoliciesResponse {
   policies: Array<{
     id: string;
@@ -72,6 +74,9 @@ export interface ListPoliciesResponse {
     rules: Array<{ match: Record<string, unknown>; decision: string }>;
     priority: number;
     enabled: boolean;
+    scope: PolicyScope;
+    agentIds: string[] | null;
+    toolIds: string[] | null;
     createdAt: string;
   }>;
   pagination: {
@@ -276,6 +281,24 @@ export const api = {
     return handleResponse<{ templates: PolicyTemplate[] }>(response);
   },
 
+  // Create a policy (used to clone an existing one across agents, #22)
+  async createPolicy(data: {
+    name: string;
+    rules: Array<{ match: Record<string, unknown>; decision: string }>;
+    priority: number;
+    enabled: boolean;
+    scope?: PolicyScope;
+    agentIds?: string[];
+    toolIds?: string[];
+  }): Promise<ListPoliciesResponse['policies'][number]> {
+    const response = await authFetch(`${baseUrl}/api/policies`, {
+      method: 'POST',
+      headers: getHeaders('application/json'),
+      body: JSON.stringify(data),
+    });
+    return handleResponse(response);
+  },
+
   // Create a policy from a template
   async createPolicyFromTemplate(
     templateId: string,
@@ -372,6 +395,8 @@ export const api = {
     from?: string;
     to?: string;
     requestId?: string;
+    verifiedAgentId?: string;
+    decidedByType?: string;
     limit?: number;
     offset?: number;
   }): Promise<ListAuditResponse> {
@@ -383,6 +408,8 @@ export const api = {
     if (params?.from) searchParams.set('from', params.from);
     if (params?.to) searchParams.set('to', params.to);
     if (params?.requestId) searchParams.set('requestId', params.requestId);
+    if (params?.verifiedAgentId) searchParams.set('verifiedAgentId', params.verifiedAgentId);
+    if (params?.decidedByType) searchParams.set('decidedByType', params.decidedByType);
     if (params?.limit) searchParams.set('limit', params.limit.toString());
     if (params?.offset) searchParams.set('offset', params.offset.toString());
 
@@ -587,10 +614,11 @@ export const adminApi = {
       lastUsedAt: number | null;
       rateLimit: number | null;
       active: boolean;
+      agentId: string | null;
     }> }>(response);
   },
 
-  async createApiKey(data: { name: string; scopes: string[]; rateLimit: number | null }) {
+  async createApiKey(data: { name: string; scopes: string[]; rateLimit: number | null; agentId?: string | null }) {
     const response = await authFetch(`${baseUrl}/api/api-keys`, {
       method: 'POST',
       headers: getHeaders('application/json'),
@@ -716,5 +744,102 @@ export const adminApi = {
       headers: getHeaders(),
     });
     return handleResponse<{ success: boolean; delivery: WebhookDeliveryRecord }>(response);
+  },
+};
+
+// ── Governance (#22): agents, per-agent budgets/spend, tool overrides ──
+
+export interface Agent {
+  id: string;
+  name: string;
+  status: 'active' | 'revoked';
+  metadata: unknown;
+  createdAt: string;
+  lastSeenAt: string | null;
+  revokedAt: string | null;
+  monthlyBudgetUsd: number | null;
+}
+
+export interface AgentSpend {
+  agentId: string;
+  tenantId: string;
+  periodSpendUsd: number;
+  window: { from: string; to: string };
+}
+
+export type OverrideAction = 'require_approval' | 'deny';
+
+export interface Override {
+  id: string;
+  agentId: string;
+  toolPattern: string;
+  action: OverrideAction;
+  reason: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+}
+
+export const governanceApi = {
+  async listAgents(): Promise<{ agents: Agent[] }> {
+    const response = await authFetch(`${baseUrl}/api/agents`, { headers: getHeaders() });
+    return handleResponse<{ agents: Agent[] }>(response);
+  },
+
+  async createAgent(data: { name: string; monthlyBudgetUsd?: number | null }): Promise<Agent & { secret: string }> {
+    const response = await authFetch(`${baseUrl}/api/agents`, {
+      method: 'POST',
+      headers: getHeaders('application/json'),
+      body: JSON.stringify(data),
+    });
+    return handleResponse<Agent & { secret: string }>(response);
+  },
+
+  // Current calendar-month spend; throws (503) when AgentLens spend is not configured.
+  async getSpend(id: string): Promise<AgentSpend> {
+    const response = await authFetch(`${baseUrl}/api/agents/${id}/spend`, { headers: getHeaders() });
+    return handleResponse<AgentSpend>(response);
+  },
+
+  // Set (positive number) or clear (null) the agent's monthly USD budget.
+  async setBudget(id: string, monthlyBudgetUsd: number | null): Promise<{ id: string; monthlyBudgetUsd: number | null }> {
+    const response = await authFetch(`${baseUrl}/api/agents/${id}/budget`, {
+      method: 'PATCH',
+      headers: getHeaders('application/json'),
+      body: JSON.stringify({ monthlyBudgetUsd }),
+    });
+    return handleResponse<{ id: string; monthlyBudgetUsd: number | null }>(response);
+  },
+
+  async revokeAgent(id: string): Promise<void> {
+    const response = await authFetch(`${baseUrl}/api/agents/${id}`, { method: 'DELETE', headers: getHeaders() });
+    if (!response.ok && response.status !== 204) {
+      const e = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(e.error || `HTTP ${response.status}`);
+    }
+  },
+
+  async listOverrides(): Promise<{ overrides: Override[] }> {
+    const response = await authFetch(`${baseUrl}/api/overrides`, { headers: getHeaders() });
+    return handleResponse<{ overrides: Override[] }>(response);
+  },
+
+  async createOverride(data: {
+    agentId: string;
+    toolPattern: string;
+    action: OverrideAction;
+    reason?: string;
+    ttlSeconds?: number;
+  }): Promise<Override> {
+    const response = await authFetch(`${baseUrl}/api/overrides`, {
+      method: 'POST',
+      headers: getHeaders('application/json'),
+      body: JSON.stringify(data),
+    });
+    return handleResponse<Override>(response);
+  },
+
+  async deleteOverride(id: string): Promise<void> {
+    const response = await authFetch(`${baseUrl}/api/overrides/${id}`, { method: 'DELETE', headers: getHeaders() });
+    await handleResponse<{ success: boolean }>(response);
   },
 };

--- a/packages/dashboard/src/components/Skeleton.tsx
+++ b/packages/dashboard/src/components/Skeleton.tsx
@@ -223,6 +223,30 @@ export function ApiKeysSkeleton() {
   );
 }
 
+/** Agents (governance) page skeleton: header + button + table */
+export function AgentsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <SkeletonBox className="h-7 w-24" />
+        <SkeletonBox className="h-10 w-36 rounded-lg" />
+      </div>
+      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <div className="px-4 py-3 bg-gray-50 border-b border-gray-200">
+          <SkeletonBox className="h-4 w-full" />
+        </div>
+        <div className="divide-y divide-gray-200">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="px-4 py-4">
+              <SkeletonBox className="h-4 w-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /** Webhooks page skeleton: header + button + table */
 export function WebhooksSkeleton() {
   return (

--- a/packages/dashboard/src/pages/Agents.tsx
+++ b/packages/dashboard/src/pages/Agents.tsx
@@ -1,0 +1,486 @@
+import { useState, useEffect, useId } from 'react';
+import {
+  governanceApi,
+  adminApi,
+  type Agent,
+  type Override,
+  type OverrideAction,
+} from '../api';
+import { ResponsiveTable, type Column } from '../components/ResponsiveTable';
+import { useToast } from '../components/Toast';
+import { Modal } from '../components/Modal';
+import { AgentsSkeleton } from '../components/Skeleton';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+
+const Spinner = () => (
+  <svg className="animate-spin -ml-1 mr-2 h-4 w-4 inline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+  </svg>
+);
+
+interface BoundKey { id: string; name: string; active: boolean; agentId: string | null }
+
+/** Budget-vs-spend bar. spend === null means spend telemetry is unavailable. */
+function BudgetBar({ budget, spend }: { budget: number | null; spend: number | null }) {
+  if (budget == null) return <span className="text-sm text-gray-400">No budget</span>;
+  const used = spend ?? 0;
+  const pct = budget > 0 ? Math.min(100, (used / budget) * 100) : 0;
+  const over = used > budget;
+  const color = over ? 'bg-red-500' : pct >= 80 ? 'bg-yellow-500' : 'bg-green-500';
+  return (
+    <div className="w-full min-w-[7rem]">
+      <div className="flex justify-between text-xs text-gray-500 mb-1">
+        <span className={over ? 'text-red-600 font-medium' : ''}>
+          {spend == null ? 'n/a' : `$${used.toFixed(2)}`}
+        </span>
+        <span>${budget.toFixed(2)}</span>
+      </div>
+      <div className="w-full bg-gray-100 rounded-full h-2">
+        <div className={`${color} h-2 rounded-full`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function Agents() {
+  const toast = useToast();
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [keys, setKeys] = useState<BoundKey[]>([]);
+  const [overrides, setOverrides] = useState<Override[]>([]);
+  const [spend, setSpend] = useState<Record<string, number | null>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create agent
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState<{ name: string; budget: string }>({ name: '', budget: '' });
+  const [isCreating, setIsCreating] = useState(false);
+  const [newSecret, setNewSecret] = useState<{ id: string; name: string; secret: string } | null>(null);
+
+  // Manage (detail) + revoke
+  const [manageId, setManageId] = useState<string | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<Agent | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  const createTitleId = useId();
+  const manageTitleId = useId();
+
+  useEffect(() => { void fetchAll(); }, []);
+
+  async function fetchAll() {
+    try {
+      setError(null);
+      const [agentsRes, keysRes, overridesRes] = await Promise.all([
+        governanceApi.listAgents(),
+        adminApi.listApiKeys(),
+        governanceApi.listOverrides(),
+      ]);
+      const list = agentsRes.agents || [];
+      setAgents(list);
+      setKeys((keysRes.keys || []).map((k) => ({ id: k.id, name: k.name, active: k.active, agentId: k.agentId })));
+      setOverrides(overridesRes.overrides || []);
+
+      // Spend is informational + may be unconfigured; fetch per active agent in
+      // parallel and never let a 503/502 break the page.
+      const active = list.filter((a) => a.status === 'active');
+      const results = await Promise.allSettled(active.map((a) => governanceApi.getSpend(a.id)));
+      const map: Record<string, number | null> = {};
+      results.forEach((r, i) => {
+        map[active[i]!.id] = r.status === 'fulfilled' ? r.value.periodSpendUsd : null;
+      });
+      setSpend(map);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load agents');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const keysFor = (id: string) => keys.filter((k) => k.agentId === id);
+  const overridesFor = (id: string) => overrides.filter((o) => o.agentId === id);
+  const manageAgent = manageId ? agents.find((a) => a.id === manageId) ?? null : null;
+
+  async function createAgent() {
+    if (isCreating) return;
+    setIsCreating(true);
+    try {
+      const raw = createForm.budget.trim();
+      let budget: number | null = null;
+      if (raw) {
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n <= 0) { toast.error('Budget must be a positive number'); return; }
+        budget = n;
+      }
+      const res = await governanceApi.createAgent({ name: createForm.name.trim(), monthlyBudgetUsd: budget });
+      setNewSecret({ id: res.id, name: res.name, secret: res.secret });
+      setShowCreate(false);
+      setCreateForm({ name: '', budget: '' });
+      toast.success('Agent registered');
+      void fetchAll();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to register agent');
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  async function revokeAgent(id: string) {
+    if (revokingId) return;
+    setRevokingId(id);
+    try {
+      await governanceApi.revokeAgent(id);
+      toast.success('Agent revoked');
+      void fetchAll();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to revoke agent');
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  const columns: Column<Agent>[] = [
+    {
+      header: 'Agent',
+      span: 3,
+      mobileLabel: 'Agent',
+      accessor: (a) => (
+        <div className="min-w-0">
+          <div className="font-medium truncate">{a.name}</div>
+          <div className="text-xs text-gray-400 font-mono truncate">{a.id}</div>
+        </div>
+      ),
+    },
+    {
+      header: 'Status',
+      span: 1,
+      tabletSpan: 1,
+      mobileLabel: 'Status',
+      accessor: (a) => (
+        <span className={`px-2 py-1 text-xs rounded ${a.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
+          {a.status === 'active' ? 'Active' : 'Revoked'}
+        </span>
+      ),
+    },
+    {
+      header: 'Budget / Spend',
+      span: 3,
+      hideOnTablet: true,
+      mobileLabel: 'Budget / Spend',
+      accessor: (a) => <BudgetBar budget={a.monthlyBudgetUsd} spend={spend[a.id] ?? null} />,
+    },
+    {
+      header: 'Keys',
+      span: 1,
+      tabletSpan: 1,
+      mobileLabel: 'Keys',
+      accessor: (a) => <span className="text-sm text-gray-500">{keysFor(a.id).length}</span>,
+    },
+    {
+      header: 'Overrides',
+      span: 2,
+      tabletSpan: 1,
+      mobileLabel: 'Overrides',
+      accessor: (a) => {
+        const n = overridesFor(a.id).length;
+        return <span className={`text-sm ${n > 0 ? 'text-yellow-700 font-medium' : 'text-gray-500'}`}>{n}</span>;
+      },
+    },
+    {
+      header: 'Actions',
+      span: 2,
+      tabletSpan: 1,
+      mobileLabel: false,
+      accessor: (a) => (
+        <div className="flex gap-3">
+          <button onClick={() => setManageId(a.id)} className="text-blue-600 hover:text-blue-800 text-sm font-medium">Manage</button>
+          {a.status === 'active' && (
+            <button onClick={() => setRevokeTarget(a)} disabled={revokingId === a.id} className="text-red-600 hover:text-red-800 text-sm font-medium disabled:opacity-50">
+              {revokingId === a.id ? <><Spinner />Revoking…</> : 'Revoke'}
+            </button>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  if (loading) return <AgentsSkeleton />;
+
+  if (error) {
+    return (
+      <div className="p-4 sm:p-6">
+        <h1 className="text-xl sm:text-2xl font-bold mb-4">Agents</h1>
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4"><p className="text-red-600">{error}</p></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold">Agents</h1>
+          <p className="text-sm text-gray-500 mt-1">Per-agent budgets, bound keys, and tool overrides.</p>
+        </div>
+        <button onClick={() => setShowCreate(true)} className="w-full sm:w-auto bg-blue-600 text-white px-4 py-2.5 rounded-lg hover:bg-blue-700 transition-colors font-medium">
+          Register Agent
+        </button>
+      </div>
+
+      {newSecret && (
+        <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+          <h3 className="font-semibold text-green-800 mb-2">Agent registered: {newSecret.name}</h3>
+          <p className="text-sm text-green-700 mb-2">Save this secret now — it will not be shown again.</p>
+          <div className="text-xs text-green-700 mb-1">Agent ID</div>
+          <code className="bg-green-100 px-3 py-2 rounded block font-mono text-sm break-all mb-2">{newSecret.id}</code>
+          <div className="text-xs text-green-700 mb-1">Secret</div>
+          <code className="bg-green-100 px-3 py-2 rounded block font-mono text-sm break-all">{newSecret.secret}</code>
+          <div className="flex gap-3 mt-3">
+            <button onClick={() => navigator.clipboard.writeText(newSecret.secret)} className="text-sm text-green-600 hover:text-green-800 font-medium">Copy secret</button>
+            <button onClick={() => setNewSecret(null)} className="text-sm text-gray-600 hover:text-gray-800">Dismiss</button>
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        onClose={() => { setRevokeTarget(null); setRevokingId(null); }}
+        onConfirm={() => { if (revokeTarget) revokeAgent(revokeTarget.id); }}
+        title="Revoke agent"
+        message={`Revoke "${revokeTarget?.name}"? Its tokens stop working immediately and bound keys are rejected. This cannot be undone.`}
+        confirmLabel="Revoke"
+        variant="danger"
+      />
+
+      {/* Create agent */}
+      <Modal open={showCreate} onClose={() => setShowCreate(false)} titleId={createTitleId} className="max-w-md">
+        <h2 id={createTitleId} className="text-xl font-bold mb-4">Register Agent</h2>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Name</label>
+            <input type="text" value={createForm.name} onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })} className="w-full border border-gray-300 rounded-lg px-3 py-2" placeholder="deploy-bot" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Monthly budget (USD)</label>
+            <input type="number" value={createForm.budget} onChange={(e) => setCreateForm({ ...createForm, budget: e.target.value })} className="w-full border border-gray-300 rounded-lg px-3 py-2" placeholder="No budget" min="0" step="0.01" />
+            <p className="text-xs text-gray-500 mt-1">Leave empty for no budget cap.</p>
+          </div>
+        </div>
+        <div className="flex gap-3 mt-6">
+          <button onClick={() => setShowCreate(false)} className="flex-1 px-4 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">Cancel</button>
+          <button onClick={createAgent} disabled={isCreating || !createForm.name.trim()} className="flex-1 px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">{isCreating ? <><Spinner />Registering…</> : 'Register'}</button>
+        </div>
+      </Modal>
+
+      {/* Manage agent */}
+      {manageAgent && (
+        <AgentManageModal
+          agent={manageAgent}
+          titleId={manageTitleId}
+          spend={spend[manageAgent.id] ?? null}
+          boundKeys={keysFor(manageAgent.id)}
+          overrides={overridesFor(manageAgent.id)}
+          onClose={() => setManageId(null)}
+          onChanged={fetchAll}
+        />
+      )}
+
+      <ResponsiveTable
+        columns={columns}
+        rows={agents}
+        keyExtractor={(a) => a.id}
+        loading={loading}
+        emptyMessage="No agents yet. Register one to start governing per-agent budgets and tools."
+        renderMobileCard={(a) => (
+          <div className="bg-white rounded-lg border border-gray-200 p-4">
+            <div className="flex items-start justify-between gap-3 mb-3">
+              <div className="min-w-0">
+                <h3 className="font-medium text-gray-900 truncate">{a.name}</h3>
+                <div className="text-xs text-gray-400 font-mono truncate">{a.id}</div>
+              </div>
+              <span className={`shrink-0 px-2 py-1 text-xs rounded ${a.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
+                {a.status === 'active' ? 'Active' : 'Revoked'}
+              </span>
+            </div>
+            <div className="mb-3"><BudgetBar budget={a.monthlyBudgetUsd} spend={spend[a.id] ?? null} /></div>
+            <div className="grid grid-cols-2 gap-2 text-sm text-gray-500 mb-3">
+              <div><span className="text-gray-400">Keys:</span> {keysFor(a.id).length}</div>
+              <div><span className="text-gray-400">Overrides:</span> {overridesFor(a.id).length}</div>
+            </div>
+            <div className="flex gap-3 pt-3 border-t border-gray-100">
+              <button onClick={() => setManageId(a.id)} className="text-blue-600 hover:text-blue-800 text-sm font-medium">Manage</button>
+              {a.status === 'active' && (
+                <button onClick={() => setRevokeTarget(a)} className="text-red-600 hover:text-red-800 text-sm font-medium">Revoke</button>
+              )}
+            </div>
+          </div>
+        )}
+      />
+    </div>
+  );
+}
+
+// ── Per-agent manage modal: budget, bound keys, tool overrides ──────
+
+function AgentManageModal({
+  agent, titleId, spend, boundKeys, overrides, onClose, onChanged,
+}: {
+  agent: Agent;
+  titleId: string;
+  spend: number | null;
+  boundKeys: BoundKey[];
+  overrides: Override[];
+  onClose: () => void;
+  onChanged: () => Promise<void> | void;
+}) {
+  const toast = useToast();
+  const [budgetInput, setBudgetInput] = useState(agent.monthlyBudgetUsd != null ? String(agent.monthlyBudgetUsd) : '');
+  const [savingBudget, setSavingBudget] = useState(false);
+  const [ov, setOv] = useState<{ toolPattern: string; action: OverrideAction; reason: string; ttlHours: string }>({
+    toolPattern: '', action: 'require_approval', reason: '', ttlHours: '',
+  });
+  const [addingOverride, setAddingOverride] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  async function saveBudget(value: number | null) {
+    if (savingBudget) return;
+    setSavingBudget(true);
+    try {
+      await governanceApi.setBudget(agent.id, value);
+      toast.success(value == null ? 'Budget cleared' : 'Budget updated');
+      await onChanged();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update budget');
+    } finally {
+      setSavingBudget(false);
+    }
+  }
+
+  // Parse + validate the budget input before saving (empty → clear; a
+  // non-positive/NaN value must NOT be sent — it would otherwise serialize to
+  // null and silently clear the budget).
+  function submitBudget() {
+    const raw = budgetInput.trim();
+    if (!raw) { void saveBudget(null); return; }
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) { toast.error('Budget must be a positive number'); return; }
+    void saveBudget(n);
+  }
+
+  async function addOverride() {
+    if (addingOverride || !ov.toolPattern.trim()) return;
+    let ttlSeconds: number | undefined;
+    const ttlRaw = ov.ttlHours.trim();
+    if (ttlRaw) {
+      const h = Number(ttlRaw);
+      if (!Number.isFinite(h) || h <= 0) { toast.error('TTL hours must be a positive number'); return; }
+      ttlSeconds = Math.round(h * 3600);
+    }
+    setAddingOverride(true);
+    try {
+      await governanceApi.createOverride({
+        agentId: agent.id,
+        toolPattern: ov.toolPattern.trim(),
+        action: ov.action,
+        reason: ov.reason.trim() || undefined,
+        ttlSeconds,
+      });
+      setOv({ toolPattern: '', action: 'require_approval', reason: '', ttlHours: '' });
+      toast.success('Override added');
+      await onChanged();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add override');
+    } finally {
+      setAddingOverride(false);
+    }
+  }
+
+  async function removeOverride(id: string) {
+    if (deletingId) return;
+    setDeletingId(id);
+    try {
+      await governanceApi.deleteOverride(id);
+      toast.success('Override removed');
+      await onChanged();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove override');
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <Modal open onClose={onClose} titleId={titleId} className="max-w-lg">
+      <h2 id={titleId} className="text-xl font-bold">{agent.name}</h2>
+      <div className="text-xs text-gray-400 font-mono mb-4 break-all">{agent.id}</div>
+
+      <div className="space-y-6">
+        {/* Budget + spend */}
+        <section>
+          <h3 className="text-sm font-semibold mb-2">Monthly budget</h3>
+          <div className="mb-2"><BudgetBar budget={agent.monthlyBudgetUsd} spend={spend} /></div>
+          <div className="flex gap-2 items-center">
+            <span className="text-gray-500">$</span>
+            <input type="number" value={budgetInput} onChange={(e) => setBudgetInput(e.target.value)} className="flex-1 border border-gray-300 rounded-lg px-3 py-2" placeholder="No budget" min="0" step="0.01" />
+            <button onClick={submitBudget} disabled={savingBudget} className="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium">{savingBudget ? <Spinner /> : 'Save'}</button>
+            {agent.monthlyBudgetUsd != null && (
+              <button onClick={() => { setBudgetInput(''); void saveBudget(null); }} disabled={savingBudget} className="px-3 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 text-sm">Clear</button>
+            )}
+          </div>
+        </section>
+
+        {/* Bound keys */}
+        <section>
+          <h3 className="text-sm font-semibold mb-2">Bound virtual keys ({boundKeys.length})</h3>
+          {boundKeys.length === 0 ? (
+            <p className="text-sm text-gray-400">No API keys are bound to this agent.</p>
+          ) : (
+            <ul className="space-y-1">
+              {boundKeys.map((k) => (
+                <li key={k.id} className="flex items-center justify-between text-sm border border-gray-100 rounded px-3 py-1.5">
+                  <span className="truncate">{k.name}</span>
+                  <span className={`shrink-0 ml-2 px-2 py-0.5 text-xs rounded ${k.active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>{k.active ? 'Active' : 'Revoked'}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Overrides */}
+        <section>
+          <h3 className="text-sm font-semibold mb-2">Tool overrides ({overrides.length})</h3>
+          {overrides.length > 0 && (
+            <ul className="space-y-1 mb-3">
+              {overrides.map((o) => (
+                <li key={o.id} className="flex items-center justify-between text-sm border border-gray-100 rounded px-3 py-1.5">
+                  <div className="min-w-0">
+                    <span className="font-mono">{o.toolPattern}</span>
+                    <span className={`ml-2 px-2 py-0.5 text-xs rounded ${o.action === 'deny' ? 'bg-red-100 text-red-800' : 'bg-yellow-100 text-yellow-800'}`}>{o.action}</span>
+                    {o.expiresAt && <span className="ml-2 text-xs text-gray-400">expires {new Date(o.expiresAt).toLocaleString()}</span>}
+                  </div>
+                  <button onClick={() => removeOverride(o.id)} disabled={deletingId === o.id} className="shrink-0 ml-2 text-red-600 hover:text-red-800 text-xs font-medium disabled:opacity-50">{deletingId === o.id ? '…' : 'Remove'}</button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="border border-gray-200 rounded-lg p-3 space-y-2 bg-gray-50">
+            <div className="grid grid-cols-2 gap-2">
+              <input type="text" value={ov.toolPattern} disabled={addingOverride} onChange={(e) => setOv({ ...ov, toolPattern: e.target.value })} className="border border-gray-300 rounded px-2 py-1.5 text-sm font-mono disabled:opacity-50" placeholder="tool pattern (e.g. delete_*)" />
+              <select value={ov.action} disabled={addingOverride} onChange={(e) => setOv({ ...ov, action: e.target.value as OverrideAction })} className="border border-gray-300 rounded px-2 py-1.5 text-sm disabled:opacity-50">
+                <option value="require_approval">require_approval</option>
+                <option value="deny">deny</option>
+              </select>
+              <input type="text" value={ov.reason} disabled={addingOverride} onChange={(e) => setOv({ ...ov, reason: e.target.value })} className="border border-gray-300 rounded px-2 py-1.5 text-sm disabled:opacity-50" placeholder="reason (optional)" />
+              <input type="number" value={ov.ttlHours} disabled={addingOverride} onChange={(e) => setOv({ ...ov, ttlHours: e.target.value })} className="border border-gray-300 rounded px-2 py-1.5 text-sm disabled:opacity-50" placeholder="TTL hours (optional)" min="0" step="0.5" />
+            </div>
+            <button onClick={addOverride} disabled={addingOverride || !ov.toolPattern.trim()} className="w-full px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 text-sm font-medium">{addingOverride ? <><Spinner />Adding…</> : 'Add override'}</button>
+          </div>
+        </section>
+      </div>
+
+      <div className="flex justify-end mt-6">
+        <button onClick={onClose} className="px-4 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">Close</button>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/dashboard/src/pages/AuditLog.tsx
+++ b/packages/dashboard/src/pages/AuditLog.tsx
@@ -22,6 +22,20 @@ const STATUS_OPTIONS = [
   { value: 'expired', label: 'Expired' },
 ];
 
+const DECIDED_BY_TYPES = [
+  { value: '', label: 'All Decisions' },
+  { value: 'policy', label: 'Policy' },
+  { value: 'human', label: 'Human' },
+  { value: 'agent', label: 'Agent' },
+  { value: 'budget_limiter', label: 'Budget limiter' },
+  { value: 'override', label: 'Override' },
+];
+
+const detailStr = (e: AuditEntryWithRequest, key: string): string | undefined => {
+  const v = (e.details as Record<string, unknown> | null)?.[key];
+  return typeof v === 'string' ? v : undefined;
+};
+
 const PAGE_SIZE = 25;
 
 const eventTypeColors: Record<string, string> = {
@@ -54,6 +68,8 @@ export default function AuditLog() {
   const actor = searchParams.get('actor') || '';
   const from = searchParams.get('from') || '';
   const to = searchParams.get('to') || '';
+  const verifiedAgentId = searchParams.get('verifiedAgentId') || '';
+  const decidedByType = searchParams.get('decidedByType') || '';
   const page = parseInt(searchParams.get('page') || '1', 10);
   const offset = (page - 1) * PAGE_SIZE;
   const totalPages = Math.ceil(total / PAGE_SIZE);
@@ -85,6 +101,8 @@ export default function AuditLog() {
         actor: actor || undefined,
         from: from || undefined,
         to: to || undefined,
+        verifiedAgentId: verifiedAgentId || undefined,
+        decidedByType: decidedByType || undefined,
         limit: PAGE_SIZE,
         offset,
       });
@@ -95,7 +113,7 @@ export default function AuditLog() {
     } finally {
       setLoading(false);
     }
-  }, [action, status, eventType, actor, from, to, offset]);
+  }, [action, status, eventType, actor, from, to, verifiedAgentId, decidedByType, offset]);
 
   useEffect(() => {
     fetchEntries();
@@ -112,7 +130,14 @@ export default function AuditLog() {
   };
 
   const clearFilters = () => setSearchParams(new URLSearchParams());
-  const hasFilters = action || status || eventType || actor || from || to;
+  const hasFilters = action || status || eventType || actor || from || to || verifiedAgentId || decidedByType;
+
+  // Free-text agent filter: commit on Enter/blur, not per keystroke.
+  const [agentInput, setAgentInput] = useState(verifiedAgentId);
+  useEffect(() => { setAgentInput(verifiedAgentId); }, [verifiedAgentId]);
+  const commitAgent = () => {
+    if (agentInput.trim() !== verifiedAgentId) updateFilter('verifiedAgentId', agentInput.trim());
+  };
 
   const columns: Column<AuditEntryWithRequest>[] = [
     {
@@ -132,18 +157,32 @@ export default function AuditLog() {
       span: 2,
       tabletSpan: 1,
       mobileLabel: 'Event',
-      accessor: (e) => (
-        <span className={`px-2 py-0.5 text-xs font-medium rounded ${eventTypeColors[e.eventType] || 'bg-gray-100 text-gray-800'}`}>
-          {e.eventType.toUpperCase()}
-        </span>
-      ),
+      accessor: (e) => {
+        const dbt = detailStr(e, 'decidedByType');
+        return (
+          <div>
+            <span className={`px-2 py-0.5 text-xs font-medium rounded ${eventTypeColors[e.eventType] || 'bg-gray-100 text-gray-800'}`}>
+              {e.eventType.toUpperCase()}
+            </span>
+            {dbt && <div className="text-xs text-gray-400 mt-0.5">{dbt}</div>}
+          </div>
+        );
+      },
     },
     {
-      header: 'Actor',
+      header: 'Actor / Agent',
       span: 2,
       hideOnTablet: true,
       mobileLabel: 'Actor',
-      accessor: (e) => <span className="text-sm text-gray-900 truncate">{e.actor}</span>,
+      accessor: (e) => {
+        const vai = detailStr(e, 'verifiedAgentId');
+        return (
+          <div className="min-w-0">
+            <div className="text-sm text-gray-900 truncate">{e.actor}</div>
+            {vai && <div className="text-xs text-gray-400 font-mono truncate">{vai}</div>}
+          </div>
+        );
+      },
     },
     {
       header: 'Action',
@@ -242,6 +281,24 @@ export default function AuditLog() {
           <div>
             <label className="block text-xs font-medium text-gray-500 mb-1">To Date</label>
             <input type="date" value={to} onChange={(e) => updateFilter('to', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">Decided By</label>
+            <select value={decidedByType} onChange={(e) => updateFilter('decidedByType', e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+              {DECIDED_BY_TYPES.map((opt) => (<option key={opt.value} value={opt.value}>{opt.label}</option>))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">Verified Agent ID</label>
+            <input
+              type="text"
+              value={agentInput}
+              onChange={(e) => setAgentInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') commitAgent(); }}
+              onBlur={commitAgent}
+              placeholder="agt_… (press Enter)"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
           </div>
         </div>
       </div>

--- a/packages/dashboard/src/pages/Policies.tsx
+++ b/packages/dashboard/src/pages/Policies.tsx
@@ -1,10 +1,24 @@
 import { useState, useEffect, useId } from 'react';
-import { api, type PolicyTemplate, type ListPoliciesResponse } from '../api';
+import { api, governanceApi, type PolicyTemplate, type ListPoliciesResponse, type Agent } from '../api';
 import { useToast } from '../components/Toast';
 import { Modal } from '../components/Modal';
 import { SkeletonBox } from '../components/Skeleton';
 
 type PolicyItem = ListPoliciesResponse['policies'][number];
+
+const SCOPE_COLORS: Record<string, string> = {
+  global: 'bg-gray-100 text-gray-600',
+  per_agent: 'bg-blue-100 text-blue-700',
+  per_tool: 'bg-purple-100 text-purple-700',
+};
+
+function ScopeBadge({ scope }: { scope: string }) {
+  return (
+    <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${SCOPE_COLORS[scope] || SCOPE_COLORS.global}`}>
+      {scope}
+    </span>
+  );
+}
 
 const CATEGORY_COLORS: Record<string, string> = {
   communication: 'bg-blue-100 text-blue-700',
@@ -38,11 +52,20 @@ export default function Policies() {
   const [error, setError] = useState<string | null>(null);
   const [showTemplates, setShowTemplates] = useState(false);
   const [creatingId, setCreatingId] = useState<string | null>(null);
+  const [agents, setAgents] = useState<Agent[]>([]);
+
+  // Clone-across-agents (#22)
+  const [cloneSource, setCloneSource] = useState<PolicyItem | null>(null);
+  const [cloneName, setCloneName] = useState('');
+  const [cloneAgentIds, setCloneAgentIds] = useState<string[]>([]);
+  const [isCloning, setIsCloning] = useState(false);
 
   const modalTitleId = useId();
+  const cloneTitleId = useId();
 
   useEffect(() => {
     fetchPolicies();
+    void fetchAgents();
   }, []);
 
   async function fetchPolicies() {
@@ -54,6 +77,43 @@ export default function Policies() {
       setError(err instanceof Error ? err.message : 'Failed to fetch policies');
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function fetchAgents() {
+    try {
+      const data = await governanceApi.listAgents();
+      setAgents(data.agents.filter((a) => a.status === 'active'));
+    } catch {
+      // Non-fatal: clone modal just shows no agent options.
+    }
+  }
+
+  function openClone(p: PolicyItem) {
+    setCloneSource(p);
+    setCloneName(`Copy of ${p.name}`);
+    setCloneAgentIds(p.scope === 'per_agent' && p.agentIds ? p.agentIds : []);
+  }
+
+  async function clonePolicy() {
+    if (!cloneSource || isCloning || cloneAgentIds.length === 0) return;
+    setIsCloning(true);
+    try {
+      await api.createPolicy({
+        name: cloneName.trim() || `Copy of ${cloneSource.name}`,
+        rules: cloneSource.rules,
+        priority: cloneSource.priority,
+        enabled: cloneSource.enabled,
+        scope: 'per_agent',
+        agentIds: cloneAgentIds,
+      });
+      toast.success('Policy cloned to selected agents');
+      setCloneSource(null);
+      await fetchPolicies();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to clone policy');
+    } finally {
+      setIsCloning(false);
     }
   }
 
@@ -122,9 +182,9 @@ export default function Policies() {
       ) : (
         <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-200">
           {policies.map((policy) => (
-            <div key={policy.id} className="p-4 flex items-center justify-between">
+            <div key={policy.id} className="p-4 flex items-center justify-between gap-4">
               <div className="min-w-0">
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
                   <span className="font-medium text-gray-900">{policy.name}</span>
                   <span
                     className={`text-xs font-medium px-2 py-0.5 rounded-full ${
@@ -135,14 +195,29 @@ export default function Policies() {
                   >
                     {policy.enabled ? 'Active' : 'Disabled'}
                   </span>
+                  <ScopeBadge scope={policy.scope} />
                 </div>
                 <p className="text-sm text-gray-500 mt-0.5">
                   {policy.rules.length} rule{policy.rules.length !== 1 ? 's' : ''} &middot; Priority {policy.priority}
+                  {policy.scope === 'per_agent' && policy.agentIds?.length ? (
+                    <> &middot; <span className="font-mono text-xs">{policy.agentIds.join(', ')}</span></>
+                  ) : null}
+                  {policy.scope === 'per_tool' && policy.toolIds?.length ? (
+                    <> &middot; tools: <span className="font-mono text-xs">{policy.toolIds.join(', ')}</span></>
+                  ) : null}
                 </p>
               </div>
-              <span className="text-xs text-gray-400 shrink-0 ml-4">
-                {new Date(policy.createdAt).toLocaleDateString()}
-              </span>
+              <div className="flex items-center gap-3 shrink-0">
+                <button
+                  onClick={() => openClone(policy)}
+                  className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+                >
+                  Clone to agents
+                </button>
+                <span className="text-xs text-gray-400">
+                  {new Date(policy.createdAt).toLocaleDateString()}
+                </span>
+              </div>
             </div>
           ))}
         </div>
@@ -199,6 +274,51 @@ export default function Policies() {
           </button>
         </div>
       </Modal>
+
+      {/* Clone-to-agents modal (#22) */}
+      {cloneSource && (
+        <Modal open onClose={() => setCloneSource(null)} titleId={cloneTitleId} className="max-w-lg">
+          <h2 id={cloneTitleId} className="text-lg font-semibold text-gray-900 mb-1">Clone policy to agents</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Creates a per-agent copy of <span className="font-medium">{cloneSource.name}</span> (same {cloneSource.rules.length} rule{cloneSource.rules.length !== 1 ? 's' : ''}, priority {cloneSource.priority}) scoped to the selected agents.
+          </p>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">New policy name</label>
+              <input type="text" value={cloneName} onChange={(e) => setCloneName(e.target.value)} className="w-full border border-gray-300 rounded-lg px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-2">Apply to agents</label>
+              {agents.length === 0 ? (
+                <p className="text-sm text-gray-400">No active agents. Register agents first.</p>
+              ) : (
+                <div className="space-y-2 max-h-56 overflow-y-auto border border-gray-200 rounded-lg p-2">
+                  {agents.map((a) => (
+                    <label key={a.id} className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={cloneAgentIds.includes(a.id)}
+                        onChange={(e) => {
+                          setCloneAgentIds((prev) =>
+                            e.target.checked ? [...prev, a.id] : prev.filter((id) => id !== a.id),
+                          );
+                        }}
+                        className="w-4 h-4 rounded"
+                      />
+                      <span className="truncate">{a.name}</span>
+                      <span className="text-xs text-gray-400 font-mono truncate">{a.id}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-3 mt-6">
+            <button onClick={() => setCloneSource(null)} className="flex-1 px-4 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">Cancel</button>
+            <button onClick={clonePolicy} disabled={isCloning || cloneAgentIds.length === 0 || !cloneName.trim()} className="flex-1 px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">{isCloning ? <><Spinner />Cloning…</> : 'Clone'}</button>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/packages/server/src/__tests__/audit-filters.test.ts
+++ b/packages/server/src/__tests__/audit-filters.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #22: GET /api/audit verifiedAgentId + decidedByType filters.
+ *
+ * Drives the REAL auditRouter against a real in-memory DB (only getDb/getDialect
+ * are redirected) — the existing audit-api.test.ts uses a mock route, so it
+ * doesn't exercise the new filters.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { Hono } from "hono";
+import { createTestDb } from "./setup.js";
+
+const ctx = createTestDb();
+
+vi.mock("../db/index.js", async () => {
+  const schema = await import("../db/schema.js");
+  return { ...schema, getDb: () => ctx.db, getDialect: () => "sqlite" as const };
+});
+
+import auditRouter from "../routes/audit.js";
+import { approvalRequests, auditLogs } from "../db/schema.js";
+
+function app() {
+  const a = new Hono();
+  a.route("/api/audit", auditRouter);
+  return a;
+}
+
+const now = new Date();
+
+async function seed() {
+  await ctx.db.insert(approvalRequests).values([
+    { id: "req-a", action: "deploy", status: "approved", urgency: "normal", createdAt: now, updatedAt: now, verifiedAgentId: "agt_alpha" },
+    { id: "req-b", action: "delete", status: "denied", urgency: "high", createdAt: now, updatedAt: now, verifiedAgentId: "agt_beta" },
+  ]);
+  await ctx.db.insert(auditLogs).values([
+    { id: "au-1", requestId: "req-a", eventType: "approved", actor: "system", details: JSON.stringify({ decidedByType: "policy" }), createdAt: now },
+    { id: "au-2", requestId: "req-b", eventType: "denied", actor: "system", details: JSON.stringify({ decidedByType: "override" }), createdAt: now },
+    { id: "au-3", requestId: "req-a", eventType: "created", actor: "system", details: JSON.stringify({ verifiedAgentId: "agt_alpha" }), createdAt: now },
+  ]);
+}
+
+beforeEach(async () => {
+  ctx.sqlite.exec("DELETE FROM audit_logs; DELETE FROM approval_requests;");
+  await seed();
+});
+afterAll(() => ctx.cleanup());
+
+interface AuditEntry { id: string }
+
+describe("GET /api/audit filters (#22)", () => {
+  it("filters by verifiedAgentId via the approvalRequests join", async () => {
+    const res = await app().request("/api/audit?verifiedAgentId=agt_alpha");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entries: AuditEntry[] };
+    expect(body.entries.map((e) => e.id).sort()).toEqual(["au-1", "au-3"]);
+  });
+
+  it("filters by decidedByType via the details JSON", async () => {
+    const res = await app().request("/api/audit?decidedByType=override");
+    const body = (await res.json()) as { entries: AuditEntry[] };
+    expect(body.entries.map((e) => e.id)).toEqual(["au-2"]);
+  });
+
+  it("ignores an unknown decidedByType value (no filter applied)", async () => {
+    const res = await app().request("/api/audit?decidedByType=bogus");
+    const body = (await res.json()) as { entries: AuditEntry[] };
+    expect(body.entries.length).toBe(3);
+  });
+
+  it("combines verifiedAgentId + decidedByType", async () => {
+    const res = await app().request("/api/audit?verifiedAgentId=agt_beta&decidedByType=override");
+    const body = (await res.json()) as { entries: AuditEntry[] };
+    expect(body.entries.map((e) => e.id)).toEqual(["au-2"]);
+  });
+});

--- a/packages/server/src/routes/audit.ts
+++ b/packages/server/src/routes/audit.ts
@@ -2,7 +2,7 @@
 
 import { Hono } from "hono";
 import { eq, and, gte, lte, desc, sql, type SQL } from "drizzle-orm";
-import { getDb, auditLogs, approvalRequests } from "../db/index.js";
+import { getDb, getDialect, auditLogs, approvalRequests } from "../db/index.js";
 
 const auditRouter = new Hono();
 
@@ -32,6 +32,8 @@ auditRouter.get("/", async (c) => {
   const from = c.req.query("from");
   const to = c.req.query("to");
   const requestId = c.req.query("requestId");
+  const verifiedAgentId = c.req.query("verifiedAgentId");
+  const decidedByType = c.req.query("decidedByType");
   const limit = Math.min(parseInt(c.req.query("limit") || "50", 10), 100);
   const offset = parseInt(c.req.query("offset") || "0", 10);
 
@@ -73,10 +75,25 @@ auditRouter.get("/", async (c) => {
     auditConditions.push(eq(auditLogs.requestId, requestId));
   }
 
-  // For action and status filters, we need to join with approvalRequests
+  // decidedByType (#22): lives in the decision audit event's details JSON
+  // (set by the auto-decision / human-decide path). Match it backend-agnostically.
+  const validDecidedByTypes = ["policy", "human", "agent", "budget_limiter", "override"];
+  if (decidedByType && validDecidedByTypes.includes(decidedByType)) {
+    auditConditions.push(
+      getDialect() === "postgres"
+        ? sql`(${auditLogs.details}::jsonb ->> 'decidedByType') = ${decidedByType}`
+        : sql`json_extract(${auditLogs.details}, '$.decidedByType') = ${decidedByType}`
+    );
+  }
+
+  // For action / status / verifiedAgentId filters, join with approvalRequests
   const requestConditions: SQL[] = [];
   if (action) {
     requestConditions.push(eq(approvalRequests.action, action));
+  }
+  // verifiedAgentId (#22): the cryptographically verified agent that made the request
+  if (verifiedAgentId) {
+    requestConditions.push(eq(approvalRequests.verifiedAgentId, verifiedAgentId));
   }
   const validStatuses = ["pending", "approved", "denied", "expired"];
   if (status && validStatuses.includes(status)) {

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -150,6 +150,7 @@ async function handleAutoDecision(opts: {
   await logAuditEvent(requestId, status, decidedBy, {
     reason: decisionReason,
     automatic: true,
+    decidedByType,
   });
 
   // Step 2: Webhook
@@ -327,6 +328,9 @@ requestsRouter.post("/", async (c) => {
     // Who actually made the request, cryptographically verified (vs the
     // unverified context.agentId claim).
     verifiedAgentId: effectiveAgentId,
+    // What kind of decision was applied (policy | budget_limiter | override);
+    // makes the audit filterable by decidedByType (#22).
+    decidedByType,
   });
 
   // Emit request.created event
@@ -560,7 +564,7 @@ requestsRouter.post("/:id/decide", async (c) => {
     id,
     decision === "approved" ? "approved" : "denied",
     decidedBy,
-    { reason, automatic: false }
+    { reason, automatic: false, decidedByType: "human" }
   );
 
   const updatedRequest = formatRequest(updatedRow);


### PR DESCRIPTION
Closes #22. Surfaces the per-agent governance primitives (built API-only in #13/#14/#17/#18/#20/#21) in the dashboard — all five areas from the issue.

## What's here

**New Agents page** (`/agents`, gated on `keys:manage`) — the per-agent control plane:
- Register / revoke agents (secret shown once, like API keys).
- Per agent: **set/clear the monthly budget** with a live **budget-vs-spend bar** (current calendar-month spend from AgentLens; gracefully shows `n/a` when spend telemetry isn't configured — `Promise.allSettled`, never breaks the page).
- The **bound virtual keys** (`apiKeys.agentId`) and the **active tool overrides** — add/remove `require_approval` / `deny` overrides with an optional TTL.

**Policies** — each policy now shows its `scope` (global / per_agent / per_tool) and the agent/tool ids it targets, plus a **"Clone to agents"** action that creates a per-agent-scoped copy across selected agents (composed from GET + POST, since there's no clone endpoint).

**Audit log** — new filters for **`verifiedAgentId`** and **`decidedByType`** (policy / human / agent / budget_limiter / override), surfaced inline in each entry. `GET /api/audit` gains both params: `verifiedAgentId` as a column filter via the existing request join; `decidedByType` matched in the decision event's `details` JSON, **dialect-aware** (sqlite `json_extract`, postgres `jsonb`), parameterized + allowlisted.

No new backend endpoints beyond the two audit filters — the dashboard composes the existing agents / api-keys / overrides / policies APIs.

## Adversarial review (33 agents) — caught + fixed

- **Dead filter:** `decidedByType` was emitted only on the decided *event*, never written to the audit `details` — so the new filter would have matched **nothing** in production (the first test masked it by seeding `details`). Now stamped into the `created` + auto-decision + human-decide audit events.
- **Silent data loss:** a non-numeric budget value (`NaN`) serialized to `null` and **silently cleared** the budget — now validated (positive number) before send, on both the create form and the per-agent editor; TTL hours likewise validated.
- Override form inputs disabled during submit.
- The review also confirmed the SQL is injection-safe (drizzle parameterization + allowlist), NULL/missing-JSON-key handling is correct, and the count query is consistent with the rows query.

## Verification
- `audit-filters.test.ts` drives the **real** `auditRouter` against an in-memory DB for both filters (incl. the JSON-extract path + combined filter).
- Full server suite green (the 1 failure is the pre-existing `rate-limiter.test.ts` Redis-fallback flake). All packages typecheck; dashboard builds + lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)