### PR TITLE
chore: add glama.json (Glama ownership claim)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "amitpaz1"
+  ]
+}


### PR DESCRIPTION
Adds `glama.json` declaring `amitpaz1` as maintainer so the server can be claimed on Glama. Required because agentkitai is a GitHub org (Glama's GitHub-OAuth auto-claim only works for personal repos). Unblocks the Glama quality-score badge the awesome-mcp-servers maintainer requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)