### PR TITLE
fix(ci): add buildx setup so docker.yml cache export works

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # docker-container driver so `cache-to: type=gha` works (the default
+      # docker driver can't export cache — the build fails without this).
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The `v0.13.0` Docker build failed with `Cache export is not supported for the docker driver`. `cache-to: type=gha` requires the `docker-container` driver, which `docker/setup-buildx-action@v3` provides (agentlens's docker job already has this). One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)