### PR TITLE
docs: per-agent governance guide + fix dead link (#33)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/getting-started' },
           { text: 'Configuration', link: '/configuration' },
+          { text: 'Per-Agent Governance', link: '/governance' },
         ]
       },
       {

--- a/docs/events.md
+++ b/docs/events.md
@@ -538,7 +538,7 @@ console.log(dispatcher.isChannelConfigured("sms" as NotificationChannelType)); /
 
 ## Source Files
 
-- Event types and filtering: [`packages/core/src/events.ts`](../packages/core/src/events.ts)
-- Notification types: [`packages/server/src/lib/notification/types.ts`](../packages/server/src/lib/notification/types.ts)
-- Dispatcher: [`packages/server/src/lib/notification/dispatcher.ts`](../packages/server/src/lib/notification/dispatcher.ts)
-- Adapters: [`packages/server/src/lib/notification/adapters/`](../packages/server/src/lib/notification/adapters/)
+- Event types and filtering: [`packages/core/src/events.ts`](https://github.com/agentkitai/agentgate/blob/main/packages/core/src/events.ts)
+- Notification types: [`packages/server/src/lib/notification/types.ts`](https://github.com/agentkitai/agentgate/blob/main/packages/server/src/lib/notification/types.ts)
+- Dispatcher: [`packages/server/src/lib/notification/dispatcher.ts`](https://github.com/agentkitai/agentgate/blob/main/packages/server/src/lib/notification/dispatcher.ts)
+- Adapters: [`packages/server/src/lib/notification/adapters/`](https://github.com/agentkitai/agentgate/tree/main/packages/server/src/lib/notification/adapters)

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,134 @@
+# Per-Agent Governance
+
+AgentGate is more than an approval queue — it's a governance plane for the AI
+agents calling your tools. Every agent gets a **verifiable identity**, and you
+attach **budgets**, **policies**, and **tool guardrails** to that identity. This
+page is the end-to-end picture; the deeper references are linked inline.
+
+## The model in one paragraph
+
+An **agent** is a registered principal with a cryptographic credential. It
+authenticates per request (an `X-Agent-Token`, or an agent-bound API key), and
+AgentGate resolves a **verified agent id** before making any decision. Budgets,
+policies, and overrides are all keyed on that verified id — never on a
+self-reported value — so a misconfigured or malicious caller can't impersonate
+another agent. Every approval request and audit row records the verified id.
+
+## 1. Agent identity
+
+Register an agent and mint credentials:
+
+```bash
+# Register an agent — returns its id (agt_…) + client secret (ags_…)
+curl -X POST $AGENTGATE_URL/api/agents -d '{ "name": "billing-bot" }'
+
+# OAuth2 client-credentials grant → a short-lived Bearer JWT
+curl -X POST $AGENTGATE_URL/api/agents/token \
+  -d '{ "client_id": "agt_…", "client_secret": "ags_…" }'
+```
+
+The agent then sends the JWT as `X-Agent-Token` on each request. AgentGate
+verifies it (HS256 over the shared `JWT_SECRET`, `typ:"agent"` claim) and stamps
+the **verified agent id** onto the request. See
+[`agent-identity.md`](/agent-identity) for the credential types, resolution
+order, liveness/revocation, and trust-boundary details.
+
+## 2. Virtual keys (agent-scoped API keys)
+
+An API key can be **bound to one agent** — a "virtual key." Requests made with
+it are attributed to that agent automatically, no token needed:
+
+```bash
+# Bind a new key to an agent. Omit agentId for a legacy "any agent" key.
+curl -X POST $AGENTGATE_URL/api/api-keys \
+  -d '{ "name": "billing-bot key", "agentId": "agt_…" }'
+```
+
+The binding is checked at use time: if the agent is revoked or the key is used
+for a different agent, the request is rejected (403). This is the lowest-friction
+way to attribute a fleet of callers without threading tokens.
+
+## 3. Per-agent budgets
+
+Cap an agent's monthly spend. Spend is **reconciled from AgentLens-priced
+telemetry** (actual model cost, not self-reported), so it reflects real usage.
+
+```bash
+# Set a monthly cap (USD)
+curl -X PATCH $AGENTGATE_URL/api/agents/agt_…/budget -d '{ "monthlyBudgetUsd": 50 }'
+
+# Read current spend vs cap
+curl $AGENTGATE_URL/api/agents/agt_…/spend     # → { periodSpendUsd, monthlyBudgetUsd }
+```
+
+Two independent flags control behavior (both default **off**):
+
+| Flag | Effect |
+|------|--------|
+| `AGENT_BUDGET_ENFORCEMENT` | An over-budget agent's next request is **denied** outright. |
+| `AGENT_BUDGET_ALERTS` | Fire a `budget.threshold` notification at **80%** and **100%** (through the normal Slack/Discord/webhook dispatcher), independent of enforcement. |
+
+Budget is a **soft guardrail**: spend is read with a short cache (re-read at 2s
+freshness near the cap), so it gates the *next* action — it can't hard-stop a
+request already in flight.
+
+## 4. Per-agent / per-tool policy scoping
+
+Policies can apply globally or be **scoped** to specific agents or tools:
+
+```jsonc
+{
+  "scope": "per_agent",        // "global" | "per_agent" | "per_tool"
+  "agentIds": ["agt_…"],       // required when scope = per_agent
+  "toolIds": ["wire_transfer"], // required when scope = per_tool
+  "rules": [ /* … matcher rules … */ ]
+}
+```
+
+`evaluatePolicy` filters by scope and keys on the **verified** agent/tool, then
+fails closed (route to human) on any error. Matcher syntax and examples live in
+[`policies.md`](/policies).
+
+## 5. MCP tool-call guardrails
+
+For agents calling tools over MCP, a per-agent **override** gates the call right
+before it runs:
+
+| Override action | Result |
+|-----------------|--------|
+| _(none)_ | allow |
+| `require_approval` | escalate to a pending approval request |
+| `deny` | synchronous error — the tool never runs (`deny` wins over `require_approval`) |
+
+```bash
+curl -X POST $AGENTGATE_URL/api/overrides \
+  -d '{ "agentId": "agt_…", "toolPattern": "delete_*", "action": "deny" }'
+```
+
+Outcomes are audit-logged and tagged OWASP **LLM06 (Excessive Agency)**,
+queryable by tool. Full details + CLI in [`mcp.md`](/mcp).
+
+## 6. How they compose
+
+When a request arrives, the initial decision follows a fixed **precedence**
+(highest first):
+
+1. **Budget** — an over-budget agent is **denied** (`decidedByType: budget_limiter`).
+2. **Override** — a matching dynamic override forces the outcome: `deny` →
+   denied, otherwise → pending human review (`override`).
+3. **Policy** — static policy rules decide allow / deny / route-to-human (`policy`).
+
+The chosen layer is recorded as `decidedByType` on the audit row, alongside the
+verified agent id and (for human decisions) the deciding user — so every
+decision is attributable to *both* the agent that asked and the layer that
+decided.
+
+## 7. In the dashboard
+
+Everything above has UI under **Agents**, **Policies**, and **Audit**:
+
+- **Agents** — list agents, set/clear budgets, see spend-vs-cap, bound virtual
+  keys, and per-agent tool overrides.
+- **Policies** — view/edit scope + bindings, and "Clone to agents."
+- **Audit** — filter by `verifiedAgentId` and `decidedByType` to see exactly
+  which agent did what and which layer governed it.


### PR DESCRIPTION
**Closes #33** (the only residual of the gateway epic #13) and **fixes the failing `Deploy Docs` job**.

### `docs/governance.md` (new)
A single end-to-end guide for the per-agent governance model — the concepts existed but were scattered across `agent-identity.md` / `policies.md` / `mcp.md`. Covers, with real endpoints/flags:
- Agent identity (registry, `POST /api/agents/token` → `X-Agent-Token`)
- Virtual keys (agent-bound API keys)
- Per-agent budgets (`PATCH /api/agents/:id/budget`, `/spend`, `AGENT_BUDGET_ENFORCEMENT`/`AGENT_BUDGET_ALERTS`)
- Per-agent/per-tool policy scoping (`global`/`per_agent`/`per_tool`)
- MCP tool-call overrides (`require_approval`/`deny`)
- The **budget > override > policy** precedence
- Where each surfaces in the dashboard

Added to the sidebar under Introduction.

### Dead-link fix
`docs/events.md` linked to `../packages/server/src/lib/notification/adapters/` — a source-tree relative link vitepress flagged as a dead link, which failed `Deploy Docs` on main. Converted those source references to absolute GitHub URLs. **`vitepress build docs` now passes locally (exit 0).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)