### PR TITLE
docs(governance): note billing-grade per-agent spend (#24)

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -72,6 +72,17 @@ Budget is a **soft guardrail**: spend is read with a short cache (re-read at 2s
 freshness near the cap), so it gates the *next* action — it can't hard-stop a
 request already in flight.
 
+> **Billing-grade attribution (AgentLens #24, A+B+C shipped).** By default, spend
+> attributes by the *self-reported* `agentId`, which is spoofable on the OTLP
+> ingest path. With AgentLens's `BILLING_GRADE_SPEND` flag enabled, spend
+> attributes only by a **cryptographically verified** agent id on **both** ingest
+> paths (the agent JWT presented as `X-Agent-Token`); unverified cost is bucketed
+> as *unattributed* rather than billed, and a signed **reconciliation** report
+> (`POST /api/internal/reconcile`) surfaces stored-vs-recompute pricing drift per
+> agent. With the flag on, per-agent spend is **billing-grade**; with it off (the
+> default), it remains the soft guardrail described above. See
+> AgentLens `docs/billing-grade-spend.md`.
+
 ## 4. Per-agent / per-tool policy scoping
 
 Policies can apply globally or be **scoped** to specific agents or tools:


### PR DESCRIPTION
Companion docs PR for **#24** — AgentLens slices A+B+C (verified attribution, OTLP verification, reconciliation) have shipped, making per-agent spend **billing-grade** behind AgentLens's default-OFF `BILLING_GRADE_SPEND` flag.

Updates `docs/governance.md` (per-agent budgets section) to document that:
- by default, spend attributes by the spoofable self-reported `agentId` (the soft guardrail);
- with `BILLING_GRADE_SPEND` enabled, spend attributes only by a **cryptographically verified** agent id on both ingest paths, unverified cost is bucketed as *unattributed*, and a signed **reconciliation** report (`POST /api/internal/reconcile`) surfaces pricing drift per agent.

Docs-only; no behavior change. See AgentLens `docs/billing-grade-spend.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)