### PR TITLE
feat(agents): revocable ingest keys + verify endpoint (#24, Option 3 PR1)

### DIFF
--- a/packages/server/drizzle/postgres/0008_soft_nova.sql
+++ b/packages/server/drizzle/postgres/0008_soft_nova.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "agents" ADD COLUMN "ingest_key_hash" text;--> statement-breakpoint
+CREATE INDEX "idx_agents_ingest_key" ON "agents" USING btree ("ingest_key_hash");

--- a/packages/server/drizzle/postgres/meta/0008_snapshot.json
+++ b/packages/server/drizzle/postgres/meta/0008_snapshot.json
@@ -1,0 +1,1160 @@
+{
+  "id": "709fab74-d920-4d3b-bee0-2cfa48206b69",
+  "prevId": "f14e46e1-b76b-442b-9d60-d1f0f8c60249",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_budget_usd": {
+          "name": "monthly_budget_usd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingest_key_hash": {
+          "name": "ingest_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_ingest_key": {
+          "name": "idx_agents_ingest_key",
+          "columns": [
+            {
+              "expression": "ingest_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decision_tokens": {
+      "name": "decision_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_history": {
+      "name": "escalation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            {
+              "expression": "rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escalation_rules": {
+      "name": "escalation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overrides": {
+      "name": "overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policies": {
+      "name": "policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_ids": {
+          "name": "tool_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            {
+              "expression": "oidc_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oidc_sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/postgres/meta/_journal.json
+++ b/packages/server/drizzle/postgres/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782153026280,
       "tag": "0007_bitter_mimic",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782416108133,
+      "tag": "0008_soft_nova",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/sqlite/0011_previous_scorpion.sql
+++ b/packages/server/drizzle/sqlite/0011_previous_scorpion.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `agents` ADD `ingest_key_hash` text;--> statement-breakpoint
+CREATE INDEX `idx_agents_ingest_key` ON `agents` (`ingest_key_hash`);

--- a/packages/server/drizzle/sqlite/meta/0011_snapshot.json
+++ b/packages/server/drizzle/sqlite/meta/0011_snapshot.json
@@ -1,0 +1,1084 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bca90c3a-9e14-4a75-bf54-f5a489a18049",
+  "prevId": "788eb4bd-ba22-4329-bd93-f32d3ac513ba",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_budget_usd": {
+          "name": "monthly_budget_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ingest_key_hash": {
+          "name": "ingest_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_agents_ingest_key": {
+          "name": "idx_agents_ingest_key",
+          "columns": [
+            "ingest_key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approval_requests": {
+      "name": "approval_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_agent_id": {
+          "name": "verified_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_action": {
+          "name": "idx_requests_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_created_at": {
+          "name": "idx_requests_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audit_request_id": {
+          "name": "idx_audit_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_request_id_approval_requests_id_fk": {
+          "name": "audit_logs_request_id_approval_requests_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "decision_tokens": {
+      "name": "decision_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "decision_tokens_token_unique": {
+          "name": "decision_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_tokens_request_id": {
+          "name": "idx_tokens_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_tokens_request_id_approval_requests_id_fk": {
+          "name": "decision_tokens_request_id_approval_requests_id_fk",
+          "tableFrom": "decision_tokens",
+          "tableTo": "approval_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_history": {
+      "name": "escalation_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "escalated_at": {
+          "name": "escalated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_channel": {
+          "name": "from_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_channel": {
+          "name": "to_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_history_request_id": {
+          "name": "idx_escalation_history_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_escalation_history_rule_id": {
+          "name": "idx_escalation_history_rule_id",
+          "columns": [
+            "rule_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "escalation_rules": {
+      "name": "escalation_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_after_sec": {
+          "name": "trigger_after_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1800
+        },
+        "escalate_to": {
+          "name": "escalate_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_escalation_rules_policy_id": {
+          "name": "idx_escalation_rules_policy_id",
+          "columns": [
+            "policy_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "overrides": {
+      "name": "overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_pattern": {
+          "name": "tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_overrides_agent_id": {
+          "name": "idx_overrides_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_overrides_expires_at": {
+          "name": "idx_overrides_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_ids": {
+          "name": "tool_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "refresh_tokens": {
+      "name": "refresh_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_refresh_tokens_hash": {
+          "name": "idx_refresh_tokens_hash",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oidc_sub": {
+          "name": "oidc_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'viewer'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_oidc_sub_unique": {
+          "name": "users_oidc_sub_unique",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": true
+        },
+        "idx_users_sub": {
+          "name": "idx_users_sub",
+          "columns": [
+            "oidc_sub"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deliveries_webhook_id": {
+          "name": "idx_deliveries_webhook_id",
+          "columns": [
+            "webhook_id"
+          ],
+          "isUnique": false
+        },
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/sqlite/meta/_journal.json
+++ b/packages/server/drizzle/sqlite/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1782153025138,
       "tag": "0010_jazzy_havok",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1782416106923,
+      "tag": "0011_previous_scorpion",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/agent-budget.test.ts
+++ b/packages/server/src/__tests__/agent-budget.test.ts
@@ -14,7 +14,7 @@ sqlite.exec(`
 CREATE TABLE IF NOT EXISTS agents (
   id text PRIMARY KEY NOT NULL, name text NOT NULL, secret_hash text NOT NULL,
   status text NOT NULL, metadata text, created_at integer NOT NULL,
-  last_seen_at integer, revoked_at integer, monthly_budget_usd real
+  last_seen_at integer, revoked_at integer, monthly_budget_usd real, ingest_key_hash text
 );
 `);
 

--- a/packages/server/src/__tests__/agent-tokens.test.ts
+++ b/packages/server/src/__tests__/agent-tokens.test.ts
@@ -21,7 +21,8 @@ CREATE TABLE IF NOT EXISTS agents (
   created_at integer NOT NULL,
   last_seen_at integer,
   revoked_at integer,
-  monthly_budget_usd real
+  monthly_budget_usd real,
+  ingest_key_hash text
 );
 `);
 

--- a/packages/server/src/__tests__/agents.test.ts
+++ b/packages/server/src/__tests__/agents.test.ts
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS agents (
   created_at integer NOT NULL,
   last_seen_at integer,
   revoked_at integer,
-  monthly_budget_usd real
+  monthly_budget_usd real,
+  ingest_key_hash text
 );
 CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
 `);

--- a/packages/server/src/__tests__/guardrails-lens.test.ts
+++ b/packages/server/src/__tests__/guardrails-lens.test.ts
@@ -17,7 +17,7 @@ sqlite.exec(`
 CREATE TABLE IF NOT EXISTS agents (
   id text PRIMARY KEY NOT NULL, name text NOT NULL, secret_hash text NOT NULL,
   status text NOT NULL, metadata text, created_at integer NOT NULL,
-  last_seen_at integer, revoked_at integer, monthly_budget_usd real
+  last_seen_at integer, revoked_at integer, monthly_budget_usd real, ingest_key_hash text
 );
 CREATE TABLE IF NOT EXISTS overrides (
   id text PRIMARY KEY NOT NULL, agent_id text NOT NULL, tool_pattern text NOT NULL,

--- a/packages/server/src/__tests__/ingest-key-wiring.test.ts
+++ b/packages/server/src/__tests__/ingest-key-wiring.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Wiring regression (#24): POST /api/internal/verify-ingest-key must be reachable
+ * by its shared-secret caller (AgentLens), i.e. the internal router must be
+ * mounted BEFORE the global user-auth middleware. Otherwise the Bearer
+ * AGENTGATE_SERVICE_TOKEN is consumed by user-auth (not an agk_ key → invalid
+ * JWT → 401) and the endpoint is dead in production. This drives the REAL app
+ * from index.ts (authMiddleware active) so a future re-mount regression fails.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { createTestDb } from "./setup.js";
+
+const ctx = createTestDb();
+vi.mock("../db/index.js", async () => {
+  const schema = await import("../db/schema.js");
+  return { ...schema, getDb: () => ctx.db };
+});
+
+import app from "../index.js";
+import { createAgent, rotateIngestKey } from "../lib/agents.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const SVC = "svc-wiring-token";
+const JWT = "test-jwt-secret-at-least-32-chars-long!!";
+
+const verify = (body: unknown, token: string | null = SVC) => {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return app.request("/api/internal/verify-ingest-key", { method: "POST", headers, body: JSON.stringify(body) });
+};
+
+describe("verify-ingest-key is reachable past the global user-auth middleware", () => {
+  beforeEach(() => {
+    setConfig(parseConfig({ jwtSecret: JWT, agentgateServiceToken: SVC }));
+  });
+  afterAll(() => resetConfig());
+
+  it("resolves a valid ingest key with the shared service token (NOT rejected by user-auth)", async () => {
+    const { agent } = await createAgent("otlp-bot");
+    const key = await rotateIngestKey(agent.id);
+    const res = await verify({ ingestKey: key });
+    expect(res.status).toBe(200); // reached the internal router — the whole point
+    expect((await res.json()).agentId).toBe(agent.id);
+  });
+
+  it("still rejects a wrong/missing service token at the router (401, not the user-auth 401)", async () => {
+    expect((await verify({ ingestKey: "x" }, "wrong")).status).toBe(401);
+    expect((await verify({ ingestKey: "x" }, null)).status).toBe(401);
+  });
+});

--- a/packages/server/src/__tests__/ingest-keys.test.ts
+++ b/packages/server/src/__tests__/ingest-keys.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Ingest keys (#24) — a revocable, ingest-scoped agent credential (agl_ingest_*)
+ * for OTLP exporters that can't refresh a 15-min token. lib/agents resolution +
+ * the internal verify route AgentLens calls.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "../db/schema.js";
+
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+
+sqlite.exec(`
+CREATE TABLE IF NOT EXISTS agents (
+  id text PRIMARY KEY NOT NULL,
+  name text NOT NULL,
+  secret_hash text NOT NULL,
+  status text NOT NULL,
+  metadata text,
+  created_at integer NOT NULL,
+  last_seen_at integer,
+  revoked_at integer,
+  monthly_budget_usd real,
+  ingest_key_hash text
+);
+CREATE INDEX IF NOT EXISTS idx_agents_ingest_key ON agents(ingest_key_hash);
+`);
+
+const h = vi.hoisted(() => ({ svcToken: "svc-tok" as string | undefined }));
+vi.mock("../db/index.js", () => ({ getDb: () => db }));
+vi.mock("../config.js", () => ({ getConfig: () => ({ agentgateServiceToken: h.svcToken }) }));
+
+import {
+  createAgent,
+  rotateIngestKey,
+  revokeIngestKey,
+  resolveAgentByIngestKey,
+  revokeAgent,
+  listAgents,
+} from "../lib/agents.js";
+import internalRouter from "../routes/internal.js";
+
+describe("ingest keys — lib/agents", () => {
+  beforeEach(() => {
+    sqlite.exec("DELETE FROM agents");
+    h.svcToken = "svc-tok";
+  });
+
+  it("issues an agl_ingest_* key that resolves back to the agent", async () => {
+    const { agent } = await createAgent("otlp-bot");
+    const key = await rotateIngestKey(agent.id);
+    expect(key).toMatch(/^agl_ingest_/);
+    expect(await resolveAgentByIngestKey(key!)).toBe(agent.id);
+    // never leaks the hash in the public view
+    const listed = await listAgents();
+    expect((listed.find((a) => a.id === agent.id) as Record<string, unknown>).ingestKeyHash).toBeUndefined();
+  });
+
+  it("rejects a wrong/empty key", async () => {
+    const { agent } = await createAgent("otlp-bot");
+    await rotateIngestKey(agent.id);
+    expect(await resolveAgentByIngestKey("agl_ingest_wrong")).toBeNull();
+    expect(await resolveAgentByIngestKey("")).toBeNull();
+    expect(await resolveAgentByIngestKey(undefined)).toBeNull();
+  });
+
+  it("rotation invalidates the previous key immediately", async () => {
+    const { agent } = await createAgent("otlp-bot");
+    const k1 = await rotateIngestKey(agent.id);
+    const k2 = await rotateIngestKey(agent.id);
+    expect(k2).not.toBe(k1);
+    expect(await resolveAgentByIngestKey(k1!)).toBeNull(); // old key dead
+    expect(await resolveAgentByIngestKey(k2!)).toBe(agent.id);
+  });
+
+  it("revoking the ingest key stops resolution but leaves the agent active", async () => {
+    const { agent } = await createAgent("otlp-bot");
+    const key = await rotateIngestKey(agent.id);
+    expect(await revokeIngestKey(agent.id)).toBe(true);
+    expect(await resolveAgentByIngestKey(key!)).toBeNull();
+    const listed = await listAgents();
+    expect(listed.find((a) => a.id === agent.id)?.status).toBe("active"); // agent itself untouched
+  });
+
+  it("a revoked AGENT's ingest key no longer resolves", async () => {
+    const { agent } = await createAgent("otlp-bot");
+    const key = await rotateIngestKey(agent.id);
+    await revokeAgent(agent.id);
+    expect(await resolveAgentByIngestKey(key!)).toBeNull();
+    // and you can't issue a key for a revoked agent
+    expect(await rotateIngestKey(agent.id)).toBeNull();
+  });
+
+  it("revokeIngestKey on a missing agent returns false", async () => {
+    expect(await revokeIngestKey("agt_nope")).toBe(false);
+  });
+});
+
+describe("POST /api/internal/verify-ingest-key", () => {
+  const app = new Hono();
+  app.route("/api/internal", internalRouter);
+
+  const call = (body: unknown, token: string | null = "svc-tok") => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    return app.request("/api/internal/verify-ingest-key", { method: "POST", headers, body: JSON.stringify(body) });
+  };
+
+  beforeEach(() => {
+    sqlite.exec("DELETE FROM agents");
+    h.svcToken = "svc-tok";
+  });
+
+  it("resolves a valid key to its agent id (with the shared service token)", async () => {
+    const { agent } = await createAgent("otlp-bot");
+    const key = await rotateIngestKey(agent.id);
+    const res = await call({ ingestKey: key });
+    expect(res.status).toBe(200);
+    expect((await res.json()).agentId).toBe(agent.id);
+  });
+
+  it("returns agentId null for an invalid/revoked key (so the caller can cache the negative)", async () => {
+    const res = await call({ ingestKey: "agl_ingest_nope" });
+    expect(res.status).toBe(200);
+    expect((await res.json()).agentId).toBeNull();
+  });
+
+  it("rejects a missing/wrong service token (401) and validates the body (400)", async () => {
+    expect((await call({ ingestKey: "x" }, null)).status).toBe(401);
+    expect((await call({ ingestKey: "x" }, "wrong")).status).toBe(401);
+    expect((await call({})).status).toBe(400);
+  });
+
+  it("returns 503 when the service token is unset (feature disabled)", async () => {
+    h.svcToken = undefined;
+    expect((await call({ ingestKey: "x" })).status).toBe(503);
+  });
+});

--- a/packages/server/src/__tests__/mcp-guardrails.test.ts
+++ b/packages/server/src/__tests__/mcp-guardrails.test.ts
@@ -15,7 +15,7 @@ sqlite.exec(`
 CREATE TABLE IF NOT EXISTS agents (
   id text PRIMARY KEY NOT NULL, name text NOT NULL, secret_hash text NOT NULL,
   status text NOT NULL, metadata text, created_at integer NOT NULL,
-  last_seen_at integer, revoked_at integer, monthly_budget_usd real
+  last_seen_at integer, revoked_at integer, monthly_budget_usd real, ingest_key_hash text
 );
 CREATE TABLE IF NOT EXISTS overrides (
   id text PRIMARY KEY NOT NULL, agent_id text NOT NULL, tool_pattern text NOT NULL,

--- a/packages/server/src/__tests__/setup.ts
+++ b/packages/server/src/__tests__/setup.ts
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS \`agents\` (
 	\`created_at\` integer NOT NULL,
 	\`last_seen_at\` integer,
 	\`revoked_at\` integer,
-	\`monthly_budget_usd\` real
+	\`monthly_budget_usd\` real,
+	\`ingest_key_hash\` text
 );
 
 CREATE TABLE IF NOT EXISTS \`audit_logs\` (

--- a/packages/server/src/__tests__/virtual-keys.test.ts
+++ b/packages/server/src/__tests__/virtual-keys.test.ts
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS agents (
   created_at integer NOT NULL,
   last_seen_at integer,
   revoked_at integer,
-  monthly_budget_usd real
+  monthly_budget_usd real,
+  ingest_key_hash text
 );
 `);
 

--- a/packages/server/src/db/schema.postgres.ts
+++ b/packages/server/src/db/schema.postgres.ts
@@ -86,8 +86,14 @@ export const agents = pgTable("agents", {
   lastSeenAt: timestamp("last_seen_at", { mode: "date" }),
   revokedAt: timestamp("revoked_at", { mode: "date" }),
   monthlyBudgetUsd: doublePrecision("monthly_budget_usd"), // per-agent USD cap; null = no budget (#13)
+  // sha256(ingest key), hex — a longer-lived, revocable, ingest-scoped credential
+  // (agl_ingest_*) for OTLP exporters that can't refresh a 15-min token (#24).
+  // Distinct from secretHash so an ingest key can NEVER authorize a gate action.
+  // null = no ingest key issued / revoked.
+  ingestKeyHash: text("ingest_key_hash"),
 }, (table) => ({
   idxAgentsStatus: index("idx_agents_status").on(table.status),
+  idxAgentsIngestKey: index("idx_agents_ingest_key").on(table.ingestKeyHash),
 }));
 
 // Webhooks table

--- a/packages/server/src/db/schema.sqlite.ts
+++ b/packages/server/src/db/schema.sqlite.ts
@@ -90,8 +90,14 @@ export const agents = sqliteTable("agents", {
   lastSeenAt: integer("last_seen_at", { mode: "timestamp" }),
   revokedAt: integer("revoked_at", { mode: "timestamp" }),
   monthlyBudgetUsd: real("monthly_budget_usd"), // per-agent USD cap; null = no budget (#13)
+  // sha256(ingest key), hex — a longer-lived, revocable, ingest-scoped credential
+  // (agl_ingest_*) for OTLP exporters that can't refresh a 15-min token (#24).
+  // Distinct from secretHash so an ingest key can NEVER authorize a gate action.
+  // null = no ingest key issued / revoked.
+  ingestKeyHash: text("ingest_key_hash"),
 }, (table) => ({
   idxAgentsStatus: index("idx_agents_status").on(table.status),
+  idxAgentsIngestKey: index("idx_agents_ingest_key").on(table.ingestKeyHash),
 }));
 
 // Webhooks table

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,6 +12,7 @@ import policiesRouter from "./routes/policies.js";
 import apiKeysRouter from "./routes/api-keys.js";
 import agentsRouter from "./routes/agents.js";
 import agentTokenRouter from "./routes/agent-tokens.js";
+import internalRouter from "./routes/internal.js";
 import webhooksRouter from "./routes/webhooks.js";
 import auditRouter from "./routes/audit.js";
 import analyticsRouter from "./routes/analytics.js";
@@ -190,6 +191,12 @@ app.route("/auth", authRouter);
 // Agent OAuth2 token endpoint (public — the agent's own agt_*/ags_* credential
 // is the auth). Must be mounted before the user-auth middleware below.
 app.route("/api/agents/token", agentTokenRouter);
+
+// Internal service-to-service routes (e.g. AgentLens verifying an ingest key).
+// Authenticated by the shared AGENTGATE_SERVICE_TOKEN inside the router, so it
+// must be mounted before the user-auth middleware (a service token is not a
+// user/api-key and would otherwise be rejected as an invalid JWT).
+app.route("/api/internal", internalRouter);
 
 // Apply auth middleware to all /api/* routes
 app.use("/api/*", authMiddleware);

--- a/packages/server/src/lib/agents.ts
+++ b/packages/server/src/lib/agents.ts
@@ -20,7 +20,7 @@ import { agents } from "../db/schema.js";
 
 export type Agent = typeof agents.$inferSelect;
 /** Secret-free view of an agent, safe to return from the API. */
-export type PublicAgent = Omit<Agent, "secretHash">;
+export type PublicAgent = Omit<Agent, "secretHash" | "ingestKeyHash">;
 
 export function hashAgentSecret(secret: string): string {
   return createHash("sha256").update(secret).digest("hex");
@@ -37,6 +37,7 @@ export function generateAgentCredential(): { id: string; secret: string } {
 function toPublic(a: Agent): PublicAgent {
   const copy: Partial<Agent> = { ...a };
   delete copy.secretHash;
+  delete copy.ingestKeyHash;
   return copy as PublicAgent;
 }
 
@@ -58,6 +59,7 @@ export async function createAgent(
     lastSeenAt: null,
     revokedAt: null,
     monthlyBudgetUsd: monthlyBudgetUsd ?? null,
+    ingestKeyHash: null,
   };
   await getDb().insert(agents).values(values);
   return { agent: toPublic(values), secret };
@@ -111,6 +113,66 @@ export async function verifyAgentCredential(
     /* ignore */
   }
   return agent;
+}
+
+// ─── Ingest keys (#24) ──────────────────────────────────────────────
+// A longer-lived, revocable, ingest-SCOPED credential for OTLP exporters that
+// can't refresh a 15-min agent token. Distinct prefix + a separate hash column
+// so an ingest key can never be presented as the agent secret (no gate auth).
+// Only sha256(key) is stored; the plaintext is shown once at issuance.
+
+/** Generate a fresh ingest key (shown once). */
+export function generateIngestKey(): string {
+  return `agl_ingest_${randomBytes(32).toString("base64url")}`;
+}
+
+/**
+ * Issue or rotate an agent's ingest key. Generates a new key, stores only its
+ * sha256 (overwriting any previous one — instantly invalidating the old key),
+ * and returns the plaintext ONCE. Returns null if the agent is missing/revoked.
+ */
+export async function rotateIngestKey(id: string): Promise<string | null> {
+  const rows = await getDb()
+    .select({ id: agents.id })
+    .from(agents)
+    .where(and(eq(agents.id, id), isNull(agents.revokedAt)))
+    .limit(1);
+  if (!rows[0]) return null;
+  const key = generateIngestKey();
+  await getDb().update(agents).set({ ingestKeyHash: hashAgentSecret(key) }).where(eq(agents.id, id));
+  return key;
+}
+
+/** Revoke an agent's ingest key (clears the stored hash). Returns false if the agent is missing. */
+export async function revokeIngestKey(id: string): Promise<boolean> {
+  const rows = await getDb().select({ id: agents.id }).from(agents).where(eq(agents.id, id)).limit(1);
+  if (!rows[0]) return false;
+  await getDb().update(agents).set({ ingestKeyHash: null }).where(eq(agents.id, id));
+  return true;
+}
+
+/**
+ * Resolve the agent id for a presented ingest key, iff it matches an ACTIVE
+ * (non-revoked) agent's stored hash; otherwise null. Lookup is by the
+ * deterministic sha256 of the high-entropy key, so a rotated/revoked key no
+ * longer matches. This is what AgentLens calls (via the internal verify route)
+ * to attribute an OTLP span — revocation takes effect immediately, bounded only
+ * by AgentLens's short verify cache.
+ */
+export async function resolveAgentByIngestKey(key: string | undefined): Promise<string | null> {
+  if (!key) return null;
+  const rows = await getDb()
+    .select({ id: agents.id })
+    .from(agents)
+    .where(
+      and(
+        eq(agents.ingestKeyHash, hashAgentSecret(key)),
+        eq(agents.status, "active"),
+        isNull(agents.revokedAt),
+      ),
+    )
+    .limit(1);
+  return rows[0]?.id ?? null;
 }
 
 export async function listAgents(): Promise<PublicAgent[]> {

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -5,7 +5,14 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 
-import { createAgent, listAgents, revokeAgent, setAgentBudget } from "../lib/agents.js";
+import {
+  createAgent,
+  listAgents,
+  revokeAgent,
+  setAgentBudget,
+  rotateIngestKey,
+  revokeIngestKey,
+} from "../lib/agents.js";
 import { fetchAgentSpend, currentMonthWindow, SpendNotConfiguredError } from "../lib/agent-spend.js";
 import { requirePermission } from "../middleware/auth.js";
 
@@ -70,6 +77,30 @@ router.patch("/:id/budget", zValidator("json", budgetSchema), async (c) => {
   const ok = await setAgentBudget(c.req.param("id"), c.req.valid("json").monthlyBudgetUsd);
   if (!ok) return c.json({ error: "Agent not found" }, 404);
   return c.json({ id: c.req.param("id"), monthlyBudgetUsd: c.req.valid("json").monthlyBudgetUsd });
+});
+
+// Issue or rotate an agent's ingest key (#24) — returns the key ONCE. Rotating
+// instantly invalidates the previous key. For OTLP exporters set once in
+// OTEL_EXPORTER_OTLP_HEADERS, no refresh needed.
+router.post("/:id/ingest-key", async (c) => {
+  const key = await rotateIngestKey(c.req.param("id"));
+  if (!key) return c.json({ error: "Agent not found or revoked" }, 404);
+  return c.json(
+    {
+      id: c.req.param("id"),
+      ingestKey: key,
+      message:
+        "Save this ingest key — it will not be shown again. Set it as the X-Agent-Ingest-Key header on your OTLP exporter (e.g. OTEL_EXPORTER_OTLP_HEADERS). Rotating or revoking it takes effect immediately.",
+    },
+    201,
+  );
+});
+
+// Revoke an agent's ingest key (clears it; the agent itself stays active).
+router.delete("/:id/ingest-key", async (c) => {
+  const ok = await revokeIngestKey(c.req.param("id"));
+  if (!ok) return c.json({ error: "Agent not found" }, 404);
+  return c.body(null, 204);
 });
 
 // Revoke an agent.

--- a/packages/server/src/routes/internal.ts
+++ b/packages/server/src/routes/internal.ts
@@ -1,0 +1,50 @@
+// @agentgate/server — Internal service-to-service routes (#24).
+//
+// POST /api/internal/verify-ingest-key — AgentLens calls this to resolve the
+// verified agent id for an OTLP ingest key it received. Authenticated by the
+// SHARED AGENTGATE_SERVICE_TOKEN bearer (the same secret AgentGate presents to
+// AgentLens's /api/internal/spend — it's a bidirectional service secret), NOT a
+// user/api-key. AgentLens caches the result briefly, so a revoked/rotated key
+// stops resolving almost immediately. Never returns the key or any secret.
+
+import { Hono } from "hono";
+import { timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+
+import { getConfig } from "../config.js";
+import { resolveAgentByIngestKey } from "../lib/agents.js";
+
+const router = new Hono();
+
+/** Constant-time bearer check against the shared service token. */
+function tokenMatches(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+// Service-token auth for every /api/internal route.
+router.use("*", async (c, next) => {
+  const expected = getConfig().agentgateServiceToken;
+  if (!expected) {
+    return c.json({ error: "Internal endpoints disabled (AGENTGATE_SERVICE_TOKEN unset)" }, 503);
+  }
+  const authHeader = c.req.header("Authorization");
+  const presented = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : "";
+  if (!presented || !tokenMatches(presented, expected)) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  return next();
+});
+
+const verifyIngestKeySchema = z.object({ ingestKey: z.string().min(1) });
+
+// Resolve an ingest key → { agentId } (null when invalid/revoked/rotated).
+router.post("/verify-ingest-key", zValidator("json", verifyIngestKeySchema), async (c) => {
+  const { ingestKey } = c.req.valid("json");
+  const agentId = await resolveAgentByIngestKey(ingestKey);
+  return c.json({ agentId });
+});
+
+export default router;


### PR DESCRIPTION
Follow-up to **#24** (billing-grade per-agent spend). After A+B+C shipped, we revisited the Slice-B OTLP fork: Option 1 (reuse the 15-min agent JWT) is a poor fit for the dominant OTLP deployment (long-running static exporters that can't refresh). This is **Option 3, PR 1 of 2** — a revocable, ingest-scoped credential. (PR 2 adds AgentLens's cached callback.)

## What
A longer-lived, **revocable**, ingest-**scoped** agent credential (`agl_ingest_*`) that an OTLP exporter sets once (e.g. `OTEL_EXPORTER_OTLP_HEADERS`, no refresh). AgentLens resolves it via the new verify endpoint with a short cache, so rotation/revocation take effect almost immediately.

- **`agents.ingest_key_hash`** column (sqlite `0011` + postgres `0008` migrations + index). Only `sha256(key)` is stored; plaintext shown once.
- **lib/agents.ts:** `generateIngestKey` / `rotateIngestKey` (issue-or-rotate, instantly invalidating the old key) / `revokeIngestKey` / `resolveAgentByIngestKey` (lookup by sha256, **active + non-revoked only**). `PublicAgent`/`toPublic` strip the new hash.
- **routes/agents.ts (admin):** `POST /:id/ingest-key` (issue/rotate) + `DELETE /:id/ingest-key` (revoke).
- **NEW routes/internal.ts:** `POST /api/internal/verify-ingest-key` — shared `AGENTGATE_SERVICE_TOKEN` bearer auth (now bidirectional) → `{ agentId }` or `{ agentId: null }`.

## Privilege separation (the key invariant)
Distinct prefix, distinct column, distinct verify path — an ingest key can **never** be presented as `X-Agent-Secret` or exchanged for a JWT, so it cannot authorize a gate action.

## Review
Adversarial find→verify review caught a **HIGH (fix-now)**: the internal router was mounted **after** the global user-auth middleware, so the service-token `Bearer` was consumed by user-auth (→ 401) and the endpoint was **dead in production** (my unit test mounted the bare router and missed it). **Fixed** by mounting it before user-auth (alongside `/api/decide`, `/api/guardrails`, `/api/agents/token`) + a **full-app wiring regression test** that drives the real `app` from `index.ts`. All other findings (secret hygiene, naming, revoke-doesn't-null-hash) were dismissed as non-issues / defense-in-depth.

## Tests
lib resolution (issue / rotate-invalidates-old / revoke / revoked-agent / wrong-key), the verify route (auth 401/503, resolve, body validation), and the wiring lock. Full server suite green (the lone failure is the pre-existing rate-limiter Redis flake). Updated the inline `agents` DDL in the test files that hand-roll it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)