### PR TITLE
feat(agent-tokens): asymmetric RS256 signing + JWKS + rotation (#40)

### DIFF
--- a/docs/agent-identity.md
+++ b/docs/agent-identity.md
@@ -115,9 +115,11 @@ within its TTL**. There is no separate token-revocation list; revoke the agent.
 
 ## Trust model & limits
 
-- **Symmetric signing.** Agent tokens are HS256 over the shared `JWT_SECRET`.
-  Any service that holds that secret can both mint and verify agent tokens.
-  There is no `kid`, no `aud`, and no asymmetric/JWKS option today.
+- **Symmetric signing by default.** Agent tokens are HS256 over the shared
+  `JWT_SECRET`; any service that holds that secret can both mint and verify
+  them. Set `AGENT_TOKEN_SIGNING_KEY` to switch to **RS256 + JWKS** so
+  downstream services verify with the *public* key only — see
+  [Asymmetric signing & JWKS](#asymmetric-signing--jwks-40).
 - **Liveness is local.** Cryptographic verification proves the id; it does
   **not** prove the agent is still active. Only AgentGate (which owns the
   `agents` table) can answer liveness. A stateless verifier gets identity, not
@@ -127,6 +129,47 @@ within its TTL**. There is no separate token-revocation list; revoke the agent.
 - **Rate limiting.** The token endpoint is not yet rate-limited per client;
   treat a leaked `ags_…` secret as you would any credential and rotate by
   re-creating the agent.
+
+## Asymmetric signing & JWKS (#40)
+
+By default the same `JWT_SECRET` mints **and** verifies agent tokens, so every
+downstream verifier (AgentLens, Lore) must hold it — one leak mints tokens
+everywhere. Setting an RS256 signing key flips this to public-key verification:
+AgentGate signs with a private key it alone holds and publishes only the public
+half at a JWKS endpoint. This is **opt-in**; unset, the HS256 fast path is used
+unchanged.
+
+- **Enable:** set `AGENT_TOKEN_SIGNING_KEY` to a PKCS#8 PEM RSA private key
+  (`AGENT_TOKEN_SIGNING_KEY_FILE` works for Docker secrets). Tokens are then
+  signed `RS256` with a `kid` header (defaults to the JWK thumbprint, or set
+  `AGENT_TOKEN_SIGNING_KID`). A malformed key fails **closed** to HS256 with a
+  logged warning — it never crashes minting.
+- **JWKS:** `GET /.well-known/jwks.json` (public, unauthenticated, public keys
+  only) serves the active signer plus any rotation keys, `Cache-Control:
+  public, max-age=300`. Downstream verifiers fetch it and verify with no shared
+  secret. Returns an empty key set when asymmetric signing is off.
+- **Verification path:** `verifyAgentToken` selects by the token's header `alg`
+  — RS-family tokens verify against the local JWKS **pinned to `RS256`** (an
+  `alg=none`/HS-swap can't down-bid), everything else uses the HS256 verifier.
+  Both paths re-check `typ:"agent"`. Enabling RS256 does **not** stop AgentGate
+  from also accepting HS256 tokens, so a rollout can be gradual.
+- **Rotation:** set the new key as `AGENT_TOKEN_SIGNING_KEY`/`_KID` and keep the
+  *previous public JWK* in `AGENT_TOKEN_VERIFY_KEYS` (a JSON array of public RSA
+  JWKs, each with a `kid`) until its last issued token expires — both verify,
+  only the new key signs. **Only public RSA members are ever published:** each
+  rotation entry is reconstructed from a `{kty,n,e,kid}` whitelist, so pasting a
+  full private JWK (or an `oct` key) by mistake cannot leak `d/p/q/...`/`k` on
+  the public endpoint. A rotation entry whose `kid` collides with the active
+  signer is dropped (the active key wins).
+- **Audience & issuer:** `AGENT_TOKEN_AUDIENCE` mints an `aud` claim and is
+  required on verify; `AGENT_TOKEN_ISSUER` mints an `iss` claim so standard
+  JWKS verifiers can pin the issuer. **Both apply only to the RS256 path** — the
+  HS256 fast path cannot scope `aud`/`iss`, and config validation warns if you
+  set them without a signing key.
+- **Known limitation:** `api-key-only` mode still rejects agent tokens even when
+  RS256 is configured (the token path is gated off wholesale in that mode). An
+  RS256 token is *not* forgeable there, so lifting this is a reasonable future
+  change — tracked, not done in this slice.
 
 ## Downstream propagation (the consumer contract)
 
@@ -140,9 +183,10 @@ SDK**. To make the tamper-evident audit trail *attributable*, AgentLens
 verifies an AgentGate agent token at ingest and stamps the verified id.
 
 - **Verification:** AgentLens already depends on `agentkit-auth`; it verifies
-  the token with the **shared `JWT_SECRET`** and the `typ:"agent"` guard. (A
-  JWKS/asymmetric option would remove the shared-secret coupling — see
-  [Future work](#future-work).)
+  the token with the **shared `JWT_SECRET`** and the `typ:"agent"` guard. When
+  AgentGate is configured for [RS256/JWKS](#asymmetric-signing--jwks-40),
+  AgentLens can instead verify against `GET /.well-known/jwks.json` and drop the
+  shared-secret coupling (the consuming change is tracked separately).
 - **Where it lands:** the verified id is written to event **metadata**
   (e.g. `metadata.verifiedAgentId`, `verificationMethod`, `verifiedAt`), **not**
   added to the hashed event fields. AgentLens events are SHA-256 hash-chained;
@@ -170,7 +214,12 @@ formalization, not a new subsystem.
 | `JWT_SECRET` | — (required when JWT/OIDC auth is enabled) | Shared HS256 secret used to sign **and** verify agent tokens. Must be ≥32 chars and not the dev placeholder. |
 | `JWT_SECRET_FILE` | — | File-based alternative to `JWT_SECRET`. |
 | `AUTH_MODE` | `dual` | `api-key-only` disables the agent-token path (legacy headers only). |
-| `jwtAccessTtl` | `900` (s) | Agent access-token lifetime. |
+| `JWT_ACCESS_TTL` | `900` (s) | Agent access-token lifetime. |
+| `AGENT_TOKEN_SIGNING_KEY` | — | PKCS#8 PEM RSA private key → sign agent tokens with **RS256** and publish the public key at `/.well-known/jwks.json`. Unset = HS256 fast path. `_FILE` supported. |
+| `AGENT_TOKEN_SIGNING_KID` | JWK thumbprint | `kid` for the active RS256 signer. |
+| `AGENT_TOKEN_VERIFY_KEYS` | — | JSON array of public RSA JWKs (each with `kid`) to also publish + accept on verify — retired signers during a rotation. |
+| `AGENT_TOKEN_AUDIENCE` | — | `aud` claim minted into RS256 tokens and required on verify (RS256 path only). |
+| `AGENT_TOKEN_ISSUER` | — | `iss` claim minted into RS256 tokens for issuer pinning (RS256 path only). |
 | `GUARDRAILS_WEBHOOK_SECRET` | — | Shared secret authenticating the reactive-guardrails webhook. |
 
 ## Security considerations
@@ -179,8 +228,8 @@ formalization, not a new subsystem.
   credentials.
 - **Sharing `JWT_SECRET` across services** (for downstream verification) widens
   the blast radius of a leak: a leaked secret lets an attacker mint agent
-  tokens accepted everywhere. Prefer a dedicated rotation process; the JWKS
-  path (future) removes this coupling.
+  tokens accepted everywhere. The [RS256/JWKS path](#asymmetric-signing--jwks-40)
+  removes this coupling — downstream verifies with the public key only.
 - **The unverified `context.agentId` is never trusted** for decisions; only the
   resolved verified id is.
 - **Forgery is gated by the `typ:"agent"` check** plus signature; the e2e suite
@@ -189,9 +238,11 @@ formalization, not a new subsystem.
 
 ## Future work
 
-- **Asymmetric signing / JWKS** (`RS256` + a published key set) so downstream
-  services verify without sharing `JWT_SECRET`, with `kid`-based rotation.
-- **`aud` scoping** so a token is only valid for its intended consumer.
+- ✅ **Asymmetric signing / JWKS** (`RS256` + a published key set, `kid`
+  rotation, `aud`/`iss` scoping) — shipped in #40, see
+  [above](#asymmetric-signing--jwks-40).
+- **RS256 tokens in `api-key-only` mode** — currently rejected wholesale even
+  though they are not forgeable; allow them when a signing key is configured.
 - **SPIFFE SVID / WIMSE** workload identity for mesh deployments
   (X.509 / Workload API), resolving to the same verified principal.
 - **RFC-8693 token exchange** for delegated/on-behalf-of agent chains.

--- a/packages/server/src/__tests__/agent-token-asymmetric.test.ts
+++ b/packages/server/src/__tests__/agent-token-asymmetric.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Asymmetric (RS256) agent tokens + JWKS (#40).
+ *
+ * Covers the opt-in RS256 signing path, the public JWKS endpoint, audience
+ * scoping, kid rotation (a retired key still verifies), and proves the default
+ * HS256 fast path is unchanged when no signing key is configured.
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import {
+  generateKeyPair,
+  exportPKCS8,
+  exportJWK,
+  calculateJwkThumbprint,
+  decodeProtectedHeader,
+  decodeJwt,
+  SignJWT,
+  type JWK,
+  type CryptoKey as JoseCryptoKey,
+} from "jose";
+import { type AuthConfig } from "agentkit-auth";
+import * as schema from "../db/schema.js";
+
+// agent-tokens.ts → agents.js → db/index.js at import time; stub the DB (these
+// tests exercise only the crypto/JWKS paths, which never touch it).
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+vi.mock("../db/index.js", () => ({ getDb: () => db }));
+
+import { signAgentToken, verifyAgentToken, AGENT_TOKEN_TYP } from "../lib/agent-tokens.js";
+import { __resetAgentTokenKeysCache } from "../lib/agent-token-keys.js";
+import wellKnownRouter from "../routes/well-known.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const TEST_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+
+function authConfig(secret = TEST_SECRET): AuthConfig {
+  return {
+    oidc: null,
+    jwt: { secret, accessTokenTtlSeconds: 900, refreshTokenTtlSeconds: 604800 },
+    authDisabled: false,
+  };
+}
+
+/** Generate an extractable RS256 keypair: PKCS#8 PEM, public JWK, FULL private JWK. */
+async function rsaKey(): Promise<{ pem: string; pub: JWK; privJwk: JWK; priv: JoseCryptoKey }> {
+  const { publicKey, privateKey } = await generateKeyPair("RS256", { extractable: true });
+  const pem = await exportPKCS8(privateKey);
+  const pub = await exportJWK(publicKey);
+  const privJwk = await exportJWK(privateKey); // includes d/p/q/dp/dq/qi
+  return { pem, pub, privJwk, priv: privateKey as JoseCryptoKey };
+}
+
+const PRIVATE_JWK_MEMBERS = ["d", "p", "q", "dp", "dq", "qi", "k"];
+
+/** Apply config + clear the key cache so the next sign/verify rebuilds it. */
+function configure(overrides: Record<string, unknown>) {
+  setConfig(parseConfig({ jwtSecret: TEST_SECRET, ...overrides }));
+  __resetAgentTokenKeysCache();
+}
+
+function jwksApp() {
+  const a = new Hono();
+  a.route("/.well-known", wellKnownRouter);
+  return a;
+}
+
+beforeEach(() => {
+  configure({}); // default: no signing key → HS256 fast path
+});
+
+afterAll(() => {
+  resetConfig();
+  __resetAgentTokenKeysCache();
+  sqlite.close();
+});
+
+describe("RS256 signing path", () => {
+  it("signs with RS256 + kid and round-trips back to the agent id", async () => {
+    const { pem } = await rsaKey();
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1" });
+
+    const token = await signAgentToken("agt_rs", authConfig());
+    const header = decodeProtectedHeader(token);
+    expect(header.alg).toBe("RS256");
+    expect(header.kid).toBe("k1");
+    expect(await verifyAgentToken(token, authConfig())).toBe("agt_rs");
+  });
+
+  it("defaults the kid to the JWK thumbprint when none is configured", async () => {
+    const { pem, pub } = await rsaKey();
+    configure({ agentTokenSigningKey: pem });
+    const expectedKid = await calculateJwkThumbprint({
+      kty: pub.kty,
+      n: pub.n,
+      e: pub.e,
+      alg: "RS256",
+      use: "sig",
+    });
+    const token = await signAgentToken("agt_rs", authConfig());
+    expect(decodeProtectedHeader(token).kid).toBe(expectedKid);
+  });
+
+  it("rejects a tampered RS256 token", async () => {
+    const { pem } = await rsaKey();
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1" });
+    const token = await signAgentToken("agt_rs", authConfig());
+    expect(await verifyAgentToken(`${token.slice(0, -3)}xyz`, authConfig())).toBeNull();
+  });
+
+  it("rejects an RS256 token signed by a key NOT in the JWKS", async () => {
+    const a = await rsaKey();
+    const b = await rsaKey();
+    configure({ agentTokenSigningKey: a.pem, agentTokenSigningKid: "k1" });
+    const forged = await new SignJWT({ typ: AGENT_TOKEN_TYP })
+      .setProtectedHeader({ alg: "RS256", kid: "rogue" })
+      .setSubject("agt_x")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(b.priv);
+    expect(await verifyAgentToken(forged, authConfig())).toBeNull();
+  });
+
+  it("rejects an RS256 token whose typ is not 'agent' (no user cross-over)", async () => {
+    const { pem, priv } = await rsaKey();
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1" });
+    const userish = await new SignJWT({ typ: "access" })
+      .setProtectedHeader({ alg: "RS256", kid: "k1" })
+      .setSubject("user_1")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(priv);
+    expect(await verifyAgentToken(userish, authConfig())).toBeNull();
+  });
+});
+
+describe("audience scoping", () => {
+  it("mints aud and accepts it; rejects when the required audience differs", async () => {
+    const { pem } = await rsaKey();
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1", agentTokenAudience: "agentlens" });
+    const token = await signAgentToken("agt_rs", authConfig());
+    expect(await verifyAgentToken(token, authConfig())).toBe("agt_rs");
+
+    // Same keys, but the verifier now requires a DIFFERENT audience.
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1", agentTokenAudience: "someone-else" });
+    expect(await verifyAgentToken(token, authConfig())).toBeNull();
+  });
+});
+
+describe("kid rotation", () => {
+  it("verifies a retired key's token AND strips its private members from the public JWKS", async () => {
+    const oldKey = await rsaKey();
+    // Feed the FULL PRIVATE JWK (the natural exportJWK output) into the rotation
+    // config — the code must publish only the public half.
+    const oldPrivJwk: JWK = { ...oldKey.privJwk, kid: "old" };
+    expect(oldPrivJwk.d).toBeDefined(); // sanity: we really are passing a private key
+    const oldToken = await new SignJWT({ typ: AGENT_TOKEN_TYP })
+      .setProtectedHeader({ alg: "RS256", kid: "old" })
+      .setSubject("agt_old")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(oldKey.priv);
+
+    const newKey = await rsaKey();
+    configure({
+      agentTokenSigningKey: newKey.pem,
+      agentTokenSigningKid: "new",
+      agentTokenVerifyKeys: JSON.stringify([oldPrivJwk]),
+    });
+
+    // New key signs going forward...
+    const newToken = await signAgentToken("agt_new", authConfig());
+    expect(decodeProtectedHeader(newToken).kid).toBe("new");
+    expect(await verifyAgentToken(newToken, authConfig())).toBe("agt_new");
+    // ...and the retired key's token still verifies during the rotation window.
+    expect(await verifyAgentToken(oldToken, authConfig())).toBe("agt_old");
+
+    // CRITICAL: the published JWKS must NOT leak the retired private key.
+    const body = (await (await jwksApp().request("/.well-known/jwks.json")).json()) as {
+      keys: JWK[];
+    };
+    const retired = body.keys.find((k) => k.kid === "old");
+    expect(retired).toBeDefined();
+    for (const m of PRIVATE_JWK_MEMBERS) expect(retired).not.toHaveProperty(m);
+  });
+
+  it("skips a non-RSA / oct rotation entry (never publishes its secret 'k')", async () => {
+    const { pem } = await rsaKey();
+    configure({
+      agentTokenSigningKey: pem,
+      agentTokenSigningKid: "k1",
+      agentTokenVerifyKeys: JSON.stringify([{ kty: "oct", kid: "leak", k: "super-secret" }]),
+    });
+    const body = (await (await jwksApp().request("/.well-known/jwks.json")).json()) as {
+      keys: JWK[];
+    };
+    expect(body.keys).toHaveLength(1); // only the active RSA signer
+    expect(body.keys.find((k) => k.kid === "leak")).toBeUndefined();
+  });
+
+  it("a rotation key colliding with the active kid is dropped (active wins)", async () => {
+    const active = await rsaKey();
+    const other = await rsaKey();
+    configure({
+      agentTokenSigningKey: active.pem,
+      agentTokenSigningKid: "dup",
+      agentTokenVerifyKeys: JSON.stringify([{ ...other.pub, kid: "dup" }]),
+    });
+    const body = (await (await jwksApp().request("/.well-known/jwks.json")).json()) as {
+      keys: JWK[];
+    };
+    const dup = body.keys.filter((k) => k.kid === "dup");
+    expect(dup).toHaveLength(1);
+    expect(dup[0].n).toBe(active.pub.n); // the active key, not the rotation entry
+  });
+});
+
+describe("issuer scoping", () => {
+  it("mints an iss claim when AGENT_TOKEN_ISSUER is set and still round-trips", async () => {
+    const { pem } = await rsaKey();
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1", agentTokenIssuer: "https://gate.example" });
+    const token = await signAgentToken("agt_rs", authConfig());
+    expect(decodeJwt(token).iss).toBe("https://gate.example");
+    expect(await verifyAgentToken(token, authConfig())).toBe("agt_rs");
+  });
+});
+
+describe("HS256 fast path is the unchanged default", () => {
+  it("signs HS256 when no signing key is configured and round-trips", async () => {
+    const token = await signAgentToken("agt_hs", authConfig());
+    expect(decodeProtectedHeader(token).alg).toBe("HS256");
+    expect(await verifyAgentToken(token, authConfig())).toBe("agt_hs");
+  });
+
+  it("falls back to HS256 (no crash) when the signing key is malformed", async () => {
+    configure({
+      agentTokenSigningKey: "-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----",
+    });
+    const token = await signAgentToken("agt_x", authConfig());
+    expect(decodeProtectedHeader(token).alg).toBe("HS256"); // failed closed to HS256
+    expect(await verifyAgentToken(token, authConfig())).toBe("agt_x");
+    // An RS256 token now has no verifier → rejected, not a 500.
+    expect(await verifyAgentToken("eyJhbGciOiJSUzI1NiJ9.e30.x", authConfig())).toBeNull();
+  });
+
+  it("rejects an RS256 token once asymmetric keys are removed (no verifier)", async () => {
+    const { pem } = await rsaKey();
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1" });
+    const token = await signAgentToken("agt_rs", authConfig());
+    configure({}); // keys gone
+    expect(await verifyAgentToken(token, authConfig())).toBeNull();
+  });
+});
+
+describe("GET /.well-known/jwks.json", () => {
+  it("returns an empty key set when no asymmetric key is configured", async () => {
+    const res = await jwksApp().request("/.well-known/jwks.json");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ keys: [] });
+  });
+
+  it("publishes the public key (kid + kty + n + e) and NO private members", async () => {
+    const { pem } = await rsaKey();
+    configure({ agentTokenSigningKey: pem, agentTokenSigningKid: "k1" });
+    const res = await jwksApp().request("/.well-known/jwks.json");
+    const body = (await res.json()) as { keys: JWK[] };
+    expect(body.keys).toHaveLength(1);
+    const jwk = body.keys[0];
+    expect(jwk.kid).toBe("k1");
+    expect(jwk.kty).toBe("RSA");
+    expect(jwk.use).toBe("sig");
+    expect(typeof jwk.n).toBe("string");
+    expect(jwk.e).toBe("AQAB");
+    // The private half must never be published.
+    for (const priv of ["d", "p", "q", "dp", "dq", "qi"]) {
+      expect(jwk).not.toHaveProperty(priv);
+    }
+  });
+});

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -216,6 +216,27 @@ export const ConfigSchema = z.object({
   /** Refresh token TTL in seconds (default: 604800 = 7 days) */
   jwtRefreshTtl: z.coerce.number().int().min(60).default(604800),
 
+  // ─── Asymmetric agent tokens (#40) ──────────────────────────────────
+  /** PKCS#8 PEM RSA private key for RS256-signing agent tokens. Unset = sign
+   *  with the shared HS256 JWT_SECRET (the local fast path, unchanged). When
+   *  set, the matching public key is published at GET /.well-known/jwks.json so
+   *  downstream verifiers (AgentLens, Lore) verify WITHOUT holding the shared
+   *  secret — one leaked secret can no longer mint tokens anywhere. */
+  agentTokenSigningKey: z.string().optional(),
+  /** Key id (kid) for the active RS256 signer. Defaults to the JWK thumbprint. */
+  agentTokenSigningKid: z.string().optional(),
+  /** JSON array of public JWKs (each with a kid) to ALSO publish + accept on
+   *  verify — retired signers kept live during a key rotation until their last
+   *  issued token expires. */
+  agentTokenVerifyKeys: z.string().optional(),
+  /** Optional audience (aud) claim minted into RS256 agent tokens and required
+   *  on verify when set (scopes a token to e.g. "agentlens"). HS256 tokens are
+   *  NOT audience-scoped — this requires AGENT_TOKEN_SIGNING_KEY. */
+  agentTokenAudience: z.string().optional(),
+  /** Optional issuer (iss) claim minted into RS256 agent tokens so standard
+   *  JWKS verifiers (AgentLens, Lore) can pin the issuer. */
+  agentTokenIssuer: z.string().optional(),
+
   // ─── Per-agent spend / budgets (#13) ────────────────────────────────
   /** AgentLens base URL — source of per-agent spend telemetry. Unset = spend
    *  reads disabled. */
@@ -326,6 +347,11 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   SPEND_READ_TIMEOUT_MS: "spendReadTimeoutMs",
   AGENT_BUDGET_ENFORCEMENT: "agentBudgetEnforcement",
   AGENT_BUDGET_ALERTS: "agentBudgetAlerts",
+  AGENT_TOKEN_SIGNING_KEY: "agentTokenSigningKey",
+  AGENT_TOKEN_SIGNING_KID: "agentTokenSigningKid",
+  AGENT_TOKEN_VERIFY_KEYS: "agentTokenVerifyKeys",
+  AGENT_TOKEN_AUDIENCE: "agentTokenAudience",
+  AGENT_TOKEN_ISSUER: "agentTokenIssuer",
 };
 
 // ============================================================================
@@ -349,6 +375,7 @@ const SECRET_KEYS = [
   "SMTP_PASS",
   "WEBHOOK_ENCRYPTION_KEY",
   "OIDC_CLIENT_SECRET",
+  "AGENT_TOKEN_SIGNING_KEY",
 ] as const;
 
 /**
@@ -463,6 +490,22 @@ export function validateProductionConfig(config: Config): string[] {
         warnings.push("OIDC_REDIRECT_URI is required when AUTH_MODE is not api-key-only");
       }
     }
+  }
+
+  // Audience scoping only applies to the RS256 path (#40); the HS256 fast path
+  // cannot set or check `aud`. Warn so an operator isn't lulled into thinking
+  // their tokens are audience-bound when they are accepted everywhere.
+  if (config.agentTokenAudience && !config.agentTokenSigningKey) {
+    warnings.push(
+      "AGENT_TOKEN_AUDIENCE has no effect without AGENT_TOKEN_SIGNING_KEY " +
+        "(audience scoping requires the RS256/JWKS path)",
+    );
+  }
+  if (config.agentTokenIssuer && !config.agentTokenSigningKey) {
+    warnings.push(
+      "AGENT_TOKEN_ISSUER has no effect without AGENT_TOKEN_SIGNING_KEY " +
+        "(the iss claim is only minted on the RS256 path)",
+    );
   }
 
   return warnings;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,6 +12,7 @@ import policiesRouter from "./routes/policies.js";
 import apiKeysRouter from "./routes/api-keys.js";
 import agentsRouter from "./routes/agents.js";
 import agentTokenRouter from "./routes/agent-tokens.js";
+import wellKnownRouter from "./routes/well-known.js";
 import internalRouter from "./routes/internal.js";
 import webhooksRouter from "./routes/webhooks.js";
 import auditRouter from "./routes/audit.js";
@@ -127,6 +128,9 @@ if (config.metricsEnabled) {
 
 // Readiness + Startup probes (public, no auth required)
 app.route("/", probesRouter);
+
+// JWKS for asymmetric agent tokens (#40) — public keys only, no auth.
+app.route("/.well-known", wellKnownRouter);
 
 // Health check endpoint (public, no auth required)
 // GET /health        → shallow check (fast, backward compatible)

--- a/packages/server/src/lib/agent-token-keys.ts
+++ b/packages/server/src/lib/agent-token-keys.ts
@@ -1,0 +1,145 @@
+// @agentgate/server — Asymmetric (RS256) agent-token keys + JWKS (#40).
+//
+// Optional, opt-in upgrade to the agent-identity spine. By default agent tokens
+// are signed with the shared HS256 JWT_SECRET, which every downstream verifier
+// (AgentLens, Lore) must ALSO hold — so one leaked secret mints tokens anywhere.
+// Set AGENT_TOKEN_SIGNING_KEY (a PKCS#8 RSA private key) and AgentGate signs
+// with RS256 instead, publishing only the PUBLIC half at
+// GET /.well-known/jwks.json. Downstream verifiers fetch the JWKS and verify
+// with no secret. Unset → the HS256 fast path is used unchanged.
+//
+// Rotation: set a NEW signing key + kid, and keep the PREVIOUS public JWK in
+// AGENT_TOKEN_VERIFY_KEYS until its last issued token expires — both stay in the
+// JWKS and verify, but only the active key signs.
+//
+// This module owns key material only (no claim shape); agent-tokens.ts owns the
+// typ/sub/aud claims, so there is no import cycle.
+
+import {
+  importPKCS8,
+  exportJWK,
+  createLocalJWKSet,
+  calculateJwkThumbprint,
+  type JWK,
+} from "jose";
+
+import { getConfig } from "../config.js";
+
+type JwksVerifier = ReturnType<typeof createLocalJWKSet>;
+
+interface KeysState {
+  /** The active RS256 signer, or null when no signing key is configured. */
+  signer: { key: CryptoKey; kid: string; audience?: string; issuer?: string } | null;
+  /** jose key resolver over every public key (active + rotation), or null. */
+  verifier: JwksVerifier | null;
+  /** The public JWKS served at /.well-known/jwks.json (empty when unconfigured). */
+  publicJwks: { keys: JWK[] };
+}
+
+// Cached as a Promise so concurrent callers share one import (key import is async).
+let cache: Promise<KeysState> | null = null;
+
+async function build(): Promise<KeysState> {
+  const cfg = getConfig();
+  const pem = cfg.agentTokenSigningKey?.trim();
+  const audience = cfg.agentTokenAudience?.trim() || undefined;
+  const issuer = cfg.agentTokenIssuer?.trim() || undefined;
+  const publicKeys: JWK[] = [];
+  let signer: KeysState["signer"] = null;
+
+  if (pem) {
+    // A bad PEM must NOT reject (the rejection would be cached forever and turn
+    // every mint + RS verify into a 500). Fail closed to the HS256 path instead.
+    try {
+      // extractable so we can derive the PUBLIC JWK to publish; the key already
+      // lives in-process, so this exposes nothing new.
+      const key = (await importPKCS8(pem, "RS256", { extractable: true })) as CryptoKey;
+      const full = await exportJWK(key); // private JWK (kty,n,e,d,p,q,...)
+      // Publish ONLY the public members — never d/p/q/dp/dq/qi.
+      const pub: JWK = { kty: full.kty, n: full.n, e: full.e, alg: "RS256", use: "sig" };
+      const kid = cfg.agentTokenSigningKid?.trim() || (await calculateJwkThumbprint(pub));
+      pub.kid = kid;
+      publicKeys.push(pub);
+      signer = { key, kid, audience, issuer };
+    } catch (err) {
+      console.error(
+        `Warning: AGENT_TOKEN_SIGNING_KEY is not a valid PKCS#8 RS256 key; ` +
+          `falling back to the HS256 path: ${String(err)}`,
+      );
+    }
+  }
+  const activeKid = signer?.kid;
+
+  // Retired signers, kept live for verification during a rotation window. These
+  // are operator-supplied, so reconstruct each from a STRICT public-RSA
+  // whitelist — never spread the raw JWK, which would publish private members
+  // (d/p/q/...) or an oct secret `k` on the public JWKS endpoint.
+  const verifyRaw = cfg.agentTokenVerifyKeys?.trim();
+  if (verifyRaw) {
+    try {
+      const parsed = JSON.parse(verifyRaw) as unknown;
+      const arr: unknown[] = Array.isArray(parsed)
+        ? parsed
+        : Array.isArray((parsed as { keys?: unknown[] })?.keys)
+          ? (parsed as { keys: unknown[] }).keys
+          : [];
+      for (const k of arr) {
+        const jwk = (k ?? {}) as JWK;
+        const ok =
+          jwk.kty === "RSA" &&
+          typeof jwk.kid === "string" &&
+          typeof jwk.n === "string" &&
+          typeof jwk.e === "string";
+        if (!ok) {
+          console.error(
+            "Warning: AGENT_TOKEN_VERIFY_KEYS entry skipped " +
+              "(must be a public RSA JWK with kty/kid/n/e)",
+          );
+          continue;
+        }
+        // The active signer is already published; a colliding kid would make
+        // verification ambiguous (rotation footgun) — the active key wins.
+        if (jwk.kid === activeKid) continue;
+        publicKeys.push({ kty: "RSA", n: jwk.n, e: jwk.e, kid: jwk.kid, alg: "RS256", use: "sig" });
+      }
+    } catch {
+      // ponytail: a malformed AGENT_TOKEN_VERIFY_KEYS must never crash token
+      // verification — log and ignore the rotation keys.
+      console.error(
+        "Warning: AGENT_TOKEN_VERIFY_KEYS is not valid JSON; ignoring rotation keys",
+      );
+    }
+  }
+
+  const verifier = publicKeys.length ? createLocalJWKSet({ keys: publicKeys }) : null;
+  return { signer, verifier, publicJwks: { keys: publicKeys } };
+}
+
+function state(): Promise<KeysState> {
+  return (cache ??= build());
+}
+
+/** The active RS256 signer, or null when only the HS256 fast path is configured. */
+export async function getActiveSigningKey(): Promise<KeysState["signer"]> {
+  return (await state()).signer;
+}
+
+/** jose JWKS resolver for verifying RS256 agent tokens, or null when none configured. */
+export async function getJwksVerifier(): Promise<JwksVerifier | null> {
+  return (await state()).verifier;
+}
+
+/** Public JWKS for GET /.well-known/jwks.json (a valid empty set when unconfigured). */
+export async function getPublicJwks(): Promise<{ keys: JWK[] }> {
+  return (await state()).publicJwks;
+}
+
+/** The configured audience to require on RS256 verify, or undefined. */
+export function getAgentTokenAudience(): string | undefined {
+  return getConfig().agentTokenAudience?.trim() || undefined;
+}
+
+/** Drop the cached keys (tests + after a config reset). */
+export function __resetAgentTokenKeysCache(): void {
+  cache = null;
+}

--- a/packages/server/src/lib/agent-tokens.ts
+++ b/packages/server/src/lib/agent-tokens.ts
@@ -9,16 +9,38 @@
 // the claim, so this check is load-bearing and must not be dropped.
 
 import { signAccessToken, verifyAccessToken, type AuthConfig } from "agentkit-auth";
+import { SignJWT, jwtVerify, decodeProtectedHeader } from "jose";
 
 import { getAgentIfActive, verifyAgentCredential } from "./agents.js";
 import { getAuthConfig } from "./auth-config.js";
+import {
+  getActiveSigningKey,
+  getJwksVerifier,
+  getAgentTokenAudience,
+} from "./agent-token-keys.js";
 
 export const AGENT_TOKEN_TYP = "agent";
 
-/** Mint a short-lived agent access token. sub = agt_* id; exp from config TTL. */
+/**
+ * Mint a short-lived agent access token. sub = agt_* id; exp from config TTL.
+ * When an RS256 signing key is configured (#40) the token is signed
+ * asymmetrically with that key's kid (and aud, if set); otherwise it is signed
+ * with the shared HS256 JWT_SECRET — the default local fast path, unchanged.
+ */
 export async function signAgentToken(agentId: string, config: AuthConfig): Promise<string> {
   // tid/role/email satisfy AccessTokenClaims' required fields but are inert:
   // agent tokens never flow through the user RBAC path (see middleware/auth.ts).
+  const signer = await getActiveSigningKey();
+  if (signer) {
+    const builder = new SignJWT({ tid: "default", role: "viewer", email: "", typ: AGENT_TOKEN_TYP })
+      .setProtectedHeader({ alg: "RS256", kid: signer.kid, typ: "JWT" })
+      .setSubject(agentId)
+      .setIssuedAt()
+      .setExpirationTime(`${config.jwt.accessTokenTtlSeconds}s`);
+    if (signer.audience) builder.setAudience(signer.audience);
+    if (signer.issuer) builder.setIssuer(signer.issuer);
+    return builder.sign(signer.key);
+  }
   return signAccessToken(
     { sub: agentId, tid: "default", role: "viewer", email: "", typ: AGENT_TOKEN_TYP },
     config,
@@ -29,12 +51,44 @@ export async function signAgentToken(agentId: string, config: AuthConfig): Promi
  * Verify a Bearer token AS an agent token. Returns the agent id (sub) iff the
  * signature is valid AND typ === "agent"; otherwise null — including for valid
  * USER tokens, which must never cross over into the agent path.
+ *
+ * The token's header `alg` selects the path: RS256-family tokens verify against
+ * the local JWKS (#40, pinned to RS256 so an HS256/none token can't down-bid),
+ * everything else uses the shared-secret HS256 verifier. Both paths re-check
+ * `typ === "agent"`; the RS256 path also enforces the configured audience.
  */
 export async function verifyAgentToken(
   token: string | undefined,
   config: AuthConfig,
 ): Promise<string | null> {
   if (!token) return null;
+
+  let alg: unknown;
+  try {
+    alg = decodeProtectedHeader(token).alg;
+  } catch {
+    return null; // not a well-formed JWS
+  }
+
+  if (typeof alg === "string" && alg.startsWith("RS")) {
+    // Whole branch is fail-safe: any resolver/verify error rejects the token
+    // (returns null) rather than throwing a 500 — an attacker can send alg=RS256
+    // at will, so this must never surface as a server error.
+    try {
+      const verifier = await getJwksVerifier();
+      if (!verifier) return null; // asymmetric token but no keys configured → reject
+      const audience = getAgentTokenAudience();
+      const { payload } = await jwtVerify(token, verifier, {
+        algorithms: ["RS256"],
+        ...(audience ? { audience } : {}),
+      });
+      if ((payload as Record<string, unknown>).typ !== AGENT_TOKEN_TYP) return null;
+      return typeof payload.sub === "string" ? payload.sub : null;
+    } catch {
+      return null;
+    }
+  }
+
   const claims = await verifyAccessToken(token, config);
   if (!claims) return null;
   if ((claims as Record<string, unknown>).typ !== AGENT_TOKEN_TYP) return null;

--- a/packages/server/src/routes/well-known.ts
+++ b/packages/server/src/routes/well-known.ts
@@ -1,0 +1,25 @@
+// @agentgate/server — Public JWKS for asymmetric agent tokens (#40).
+//
+// GET /.well-known/jwks.json — the PUBLIC half of the RS256 agent-token signing
+// key(s). Downstream verifiers (AgentLens, Lore) fetch this to verify agent
+// tokens without holding the shared HS256 secret. Returns a valid empty key set
+// when no asymmetric key is configured (HS256 fast path). PUBLIC — public keys
+// only, mounted before the user-auth middleware.
+
+import { Hono } from "hono";
+
+import { getPublicJwks } from "../lib/agent-token-keys.js";
+
+const router = new Hono();
+
+router.get("/jwks.json", async (c) => {
+  const jwks = await getPublicJwks();
+  // Short cache: long enough to amortize fetches, short enough that a rotation
+  // propagates within minutes. RFC 7517 media type for a JWK Set.
+  return c.body(JSON.stringify(jwks), 200, {
+    "content-type": "application/jwk-set+json",
+    "cache-control": "public, max-age=300",
+  });
+});
+
+export default router;


### PR DESCRIPTION
Closes #40.

## What

Opt-in **RS256** signing for agent tokens, with a public **JWKS** endpoint, **kid rotation**, and **aud/iss** scoping. The shared-secret **HS256 path stays the default** and is byte-for-byte unchanged when no signing key is configured — this is purely additive.

**Why:** today every downstream verifier (AgentLens, Lore) must hold the shared `JWT_SECRET` to verify agent tokens, so one leak mints tokens everywhere. With a private signing key, AgentGate publishes only the public half at `GET /.well-known/jwks.json` and downstream verifies with no secret. This is the substrate the cross-product identity-binding work (agentlens #97 / #98, agentgate SPIFFE #41) builds on.

## How

- `AGENT_TOKEN_SIGNING_KEY` (PKCS#8 PEM, `_FILE` supported) → sign `RS256` with a `kid` header (defaults to the JWK thumbprint). `GET /.well-known/jwks.json` serves the public key set (RFC 7517 media type, `max-age=300`, mounted before user-auth). Empty set when off.
- `verifyAgentToken` selects by header `alg`: RS-family → local JWKS **pinned to RS256** (no `alg=none`/HS down-bid); else HS256. Both re-check `typ:"agent"`. RS256 and HS256 are accepted concurrently, so rollout can be gradual.
- **Rotation:** keep a retired public JWK in `AGENT_TOKEN_VERIFY_KEYS` (JSON array) until its last token expires.
- `AGENT_TOKEN_AUDIENCE` / `AGENT_TOKEN_ISSUER` → `aud`/`iss` on the RS256 path; config validation warns if either is set without a signing key (they have no effect on HS256).

## Security review (find→verify, folded in)

A 4-agent adversarial pass found + I fixed a **fix-now private-key disclosure**: the rotation path originally spread the raw operator JWK into the public JWKS, so pasting a full private JWK (the natural `exportJWK` output) would leak `d/p/q/...` on the public endpoint. Now every rotation entry is reconstructed from a strict `{kty,n,e,kid}` public-RSA whitelist (oct/private keys skipped; active-kid collisions dropped). Also folded: a malformed signing key **fails closed to HS256** instead of poisoning the cached promise into a request-triggerable 500; the RS verify branch is fully throw-safe.

A test feeds a **full private JWK** into rotation and asserts the JWKS exposes no private members.

## Tests / validation

- 15 new tests (`agent-token-asymmetric.test.ts`): RS256 round-trip + kid header, thumbprint-default kid, tamper/wrong-key/typ rejection, **JWKS publishes no private members**, rotation (retired key verifies + sanitized), non-RSA skip, kid-collision drop, aud enforcement, iss claim, malformed-key HS256 fallback.
- Full server suite green (754/755; the 1 failure is the pre-existing `rate-limiter.test.ts` Redis-fallback flake, unrelated). `tsc` clean, `pnpm build` + `docs:build` green.

## Deferred (documented)

`api-key-only` mode still rejects agent tokens even when RS256 is configured (gated off wholesale). An RS256 token isn't forgeable there, so lifting this is a reasonable follow-up — noted in `docs/agent-identity.md` Future work, out of this slice.
