### PR TITLE
feat(identity): accept external SPIFFE JWT-SVID as a verified principal (#41)

### DIFF
--- a/docs/agent-identity.md
+++ b/docs/agent-identity.md
@@ -171,6 +171,35 @@ unchanged.
   RS256 token is *not* forgeable there, so lifting this is a reasonable future
   change — tracked, not done in this slice.
 
+## External SPIFFE / WIMSE workload identity (#41)
+
+Enterprises already running a SPIFFE/SPIRE (or WIMSE) workload-identity plane can
+present a **JWT-SVID** on `X-Agent-Token` instead of minting an AgentGate token.
+AgentGate verifies it against the trust domain's bundle and resolves it to the
+SAME verified-principal slot — the principal id is the **SPIFFE ID** itself
+(e.g. `spiffe://example.org/agent/checkout`).
+
+- **Verification:** signature checked against the trust bundle (asymmetric algs
+  only — `RS*`/`PS*`/`ES*`/`EdDSA`, never HS/none); the **audience MUST match**
+  `SPIFFE_AUDIENCE` (mandatory per the SPIFFE JWT-SVID spec); `exp` (and the
+  optional `SPIFFE_MAX_SVID_AGE`) enforced; `sub` must be
+  `spiffe://<SPIFFE_TRUST_DOMAIN>/<non-empty path>`. Verification is fail-safe —
+  any error rejects the SVID, never 500s.
+- **Enable:** set `SPIFFE_AUDIENCE` **and** `SPIFFE_TRUST_DOMAIN` **and** a
+  bundle (`SPIFFE_JWKS_URL` or inline `SPIFFE_TRUST_BUNDLE`). All three are
+  required — a partial config logs a "DISABLED" warning. Requiring the trust
+  domain prevents a multi-domain/federation bundle from authenticating an
+  unexpected domain.
+- **Externally attested:** a SPIFFE principal is **not** looked up in the
+  `agents` table (no liveness check) — the platform attests it; rely on
+  short-lived SVIDs (and optionally `SPIFFE_MAX_SVID_AGE`) for revocation.
+- **Limitation:** because a SPIFFE principal isn't a registered `agt_*`, it is
+  **not** subject to per-agent budgets/policies (those key on the agents table) —
+  binding a SPIFFE ID to a registered agent for budget/policy scoping is future
+  work. Resolution order is unchanged: an AgentGate agent token wins; the SVID is
+  tried only when no live agent token resolves; both are gated off in
+  `api-key-only` mode.
+
 ## Downstream propagation (the consumer contract)
 
 The same verified identity is intended to flow to the rest of the platform.
@@ -220,6 +249,11 @@ formalization, not a new subsystem.
 | `AGENT_TOKEN_VERIFY_KEYS` | — | JSON array of public RSA JWKs (each with `kid`) to also publish + accept on verify — retired signers during a rotation. |
 | `AGENT_TOKEN_AUDIENCE` | — | `aud` claim minted into RS256 tokens and required on verify (RS256 path only). |
 | `AGENT_TOKEN_ISSUER` | — | `iss` claim minted into RS256 tokens for issuer pinning (RS256 path only). |
+| `SPIFFE_AUDIENCE` | — | Required SVID audience. Set with `SPIFFE_TRUST_DOMAIN` + a bundle to enable SPIFFE. |
+| `SPIFFE_TRUST_DOMAIN` | — | Trust domain to pin SVID subjects to (e.g. `example.org`). Required to enable SPIFFE. |
+| `SPIFFE_JWKS_URL` | — | URL of the SPIFFE trust bundle (JWKS). Validated as a URL. |
+| `SPIFFE_TRUST_BUNDLE` | — | Inline trust bundle (JWKS JSON), alternative to the URL. |
+| `SPIFFE_MAX_SVID_AGE` | — | Optional max SVID age in seconds (checked against `iat`). |
 | `GUARDRAILS_WEBHOOK_SECRET` | — | Shared secret authenticating the reactive-guardrails webhook. |
 
 ## Security considerations
@@ -243,8 +277,11 @@ formalization, not a new subsystem.
   [above](#asymmetric-signing--jwks-40).
 - **RS256 tokens in `api-key-only` mode** — currently rejected wholesale even
   though they are not forgeable; allow them when a signing key is configured.
-- **SPIFFE SVID / WIMSE** workload identity for mesh deployments
-  (X.509 / Workload API), resolving to the same verified principal.
+- ✅ **SPIFFE JWT-SVID / WIMSE** workload identity — shipped in #41 (JWT-SVID via
+  the trust bundle, resolving to the SPIFFE ID as the principal). See
+  [above](#external-spiffe--wimse-workload-identity-41). Still open: X.509-SVID
+  (Workload API / mTLS), and **binding a SPIFFE ID to a registered `agt_*`** so
+  per-agent budgets/policies apply.
 - **RFC-8693 token exchange** for delegated/on-behalf-of agent chains.
 - **Token-endpoint rate limiting** and a credential-rotation playbook
   (dual-active secret window).

--- a/packages/server/src/__tests__/agent-tokens.test.ts
+++ b/packages/server/src/__tests__/agent-tokens.test.ts
@@ -6,6 +6,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
 import { Hono } from "hono";
 import { signAccessToken, type AuthConfig } from "agentkit-auth";
+import { generateKeyPair, exportJWK, SignJWT, type JWK } from "jose";
 import * as schema from "../db/schema.js";
 
 const sqlite = new Database(":memory:");
@@ -34,6 +35,7 @@ import {
   verifyAgentToken,
   resolveVerifiedAgentId,
 } from "../lib/agent-tokens.js";
+import { __resetSpiffeCache } from "../lib/spiffe.js";
 import agentTokenRouter from "../routes/agent-tokens.js";
 import { parseConfig, setConfig, resetConfig } from "../config.js";
 
@@ -246,5 +248,52 @@ describe("resolveVerifiedAgentId", () => {
 
   it("returns null when nothing is presented", async () => {
     expect(await resolveVerifiedAgentId({}, "dual")).toBeNull();
+  });
+});
+
+describe("resolveVerifiedAgentId — external SPIFFE SVID (#41)", () => {
+  const TD = "example.org";
+  const AUD = "spiffe://example.org/agentgate";
+
+  async function setupSpiffe() {
+    const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+    const jwk = (await exportJWK(publicKey)) as JWK;
+    jwk.kid = "td1";
+    jwk.alg = "ES256";
+    jwk.use = "sig";
+    setConfig(
+      parseConfig({
+        jwtSecret: TEST_SECRET,
+        spiffeAudience: AUD,
+        spiffeTrustDomain: TD,
+        spiffeTrustBundle: JSON.stringify({ keys: [jwk] }),
+      }),
+    );
+    __resetSpiffeCache();
+    return privateKey;
+  }
+  const mkSvid = (priv: CryptoKey, sub: string) =>
+    new SignJWT({})
+      .setProtectedHeader({ alg: "ES256", kid: "td1" })
+      .setSubject(sub)
+      .setAudience(AUD)
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(priv);
+
+  afterAll(() => __resetSpiffeCache());
+
+  it("resolves a valid SPIFFE SVID to its SPIFFE ID (no agents-table lookup)", async () => {
+    const priv = await setupSpiffe();
+    const token = await mkSvid(priv, "spiffe://example.org/agent/checkout");
+    expect(await resolveVerifiedAgentId({ agentToken: token }, "dual")).toBe(
+      "spiffe://example.org/agent/checkout",
+    );
+  });
+
+  it("ignores a SPIFFE SVID in api-key-only mode (token path gated off)", async () => {
+    const priv = await setupSpiffe();
+    const token = await mkSvid(priv, "spiffe://example.org/agent/checkout");
+    expect(await resolveVerifiedAgentId({ agentToken: token }, "api-key-only")).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/spiffe.test.ts
+++ b/packages/server/src/__tests__/spiffe.test.ts
@@ -1,0 +1,172 @@
+/**
+ * External SPIFFE JWT-SVID verification (#41).
+ *
+ * AgentGate accepts a SPIFFE JWT-SVID (verified against the trust bundle) as a
+ * verified principal = the SPIFFE ID. Covers the mandatory audience check, the
+ * trust-domain pin, asymmetric-only signing, and the disabled-by-default state.
+ */
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { generateKeyPair, exportJWK, SignJWT, type JWK, type CryptoKey as JoseCryptoKey } from "jose";
+
+import { verifySpiffeSvid, spiffeEnabled, __resetSpiffeCache } from "../lib/spiffe.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const TD = "example.org";
+const AUD = "spiffe://example.org/agentgate";
+
+async function trustDomainKey(kid = "td1") {
+  const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+  const jwk = (await exportJWK(publicKey)) as JWK;
+  jwk.kid = kid;
+  jwk.alg = "ES256";
+  jwk.use = "sig";
+  return { priv: privateKey as JoseCryptoKey, jwk, kid };
+}
+
+async function svid(
+  priv: JoseCryptoKey,
+  kid: string,
+  opts: { sub?: string; aud?: string | string[] } = {},
+) {
+  const b = new SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid })
+    .setSubject(opts.sub ?? `spiffe://${TD}/agent/checkout`)
+    .setIssuedAt()
+    .setExpirationTime("5m");
+  if (opts.aud !== undefined) b.setAudience(opts.aud);
+  return b.sign(priv);
+}
+
+/** Configure the trust bundle inline (no network) + reset the verifier cache. */
+async function configure(overrides: Record<string, unknown>, jwk?: JWK) {
+  setConfig(
+    parseConfig({
+      ...(jwk ? { spiffeTrustBundle: JSON.stringify({ keys: [jwk] }) } : {}),
+      ...overrides,
+    }),
+  );
+  __resetSpiffeCache();
+}
+
+beforeEach(() => {
+  resetConfig();
+  __resetSpiffeCache();
+});
+afterAll(() => {
+  resetConfig();
+  __resetSpiffeCache();
+});
+
+describe("verifySpiffeSvid", () => {
+  it("verifies a valid SVID and returns the SPIFFE ID", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    expect(spiffeEnabled()).toBe(true);
+    const token = await svid(k.priv, k.kid, { aud: AUD });
+    expect(await verifySpiffeSvid(token)).toBe(`spiffe://${TD}/agent/checkout`);
+  });
+
+  it("accepts an aud array that includes the configured audience", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    const token = await svid(k.priv, k.kid, { aud: ["https://other", AUD] });
+    expect(await verifySpiffeSvid(token)).toBe(`spiffe://${TD}/agent/checkout`);
+  });
+
+  it("rejects a missing or wrong audience (spec mandates audience validation)", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    expect(await verifySpiffeSvid(await svid(k.priv, k.kid))).toBeNull(); // no aud
+    expect(await verifySpiffeSvid(await svid(k.priv, k.kid, { aud: "spiffe://example.org/other" }))).toBeNull();
+  });
+
+  it("rejects a SVID from a different trust domain", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    const token = await svid(k.priv, k.kid, { sub: "spiffe://evil.org/agent/x", aud: AUD });
+    expect(await verifySpiffeSvid(token)).toBeNull();
+  });
+
+  it("rejects a non-spiffe subject", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    const token = await svid(k.priv, k.kid, { sub: "agt_not_spiffe", aud: AUD });
+    expect(await verifySpiffeSvid(token)).toBeNull();
+  });
+
+  it("rejects a SVID signed by a key not in the trust bundle", async () => {
+    const inBundle = await trustDomainKey("td1");
+    const rogue = await trustDomainKey("rogue");
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, inBundle.jwk);
+    const token = await svid(rogue.priv, "rogue", { aud: AUD });
+    expect(await verifySpiffeSvid(token)).toBeNull();
+  });
+
+  it("rejects an HS256 token (asymmetric algs only)", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    const hs = await new SignJWT({})
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject(`spiffe://${TD}/agent/checkout`)
+      .setAudience(AUD)
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode("a-shared-secret-at-least-32-chars-long!!"));
+    expect(await verifySpiffeSvid(hs)).toBeNull();
+  });
+
+  it("rejects a bare trust-domain root with no workload path", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    const token = await svid(k.priv, k.kid, { sub: `spiffe://${TD}/`, aud: AUD });
+    expect(await verifySpiffeSvid(token)).toBeNull();
+  });
+
+  it("rejects an SVID older than SPIFFE_MAX_SVID_AGE", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD, spiffeMaxSvidAge: 60 }, k.jwk);
+    const now = Math.floor(Date.now() / 1000);
+    const old = await new SignJWT({})
+      .setProtectedHeader({ alg: "ES256", kid: k.kid })
+      .setSubject(`spiffe://${TD}/agent/checkout`)
+      .setAudience(AUD)
+      .setIssuedAt(now - 7200)
+      .setExpirationTime(now + 7200)
+      .sign(k.priv);
+    expect(await verifySpiffeSvid(old)).toBeNull();
+    expect(await verifySpiffeSvid(await svid(k.priv, k.kid, { aud: AUD }))).toBe(`spiffe://${TD}/agent/checkout`);
+  });
+});
+
+describe("disabled by default", () => {
+  it("is off (returns null) when no audience is configured, even with a bundle", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeTrustDomain: TD }, k.jwk); // bundle but NO audience
+    expect(spiffeEnabled()).toBe(false);
+    expect(await verifySpiffeSvid(await svid(k.priv, k.kid, { aud: AUD }))).toBeNull();
+  });
+
+  it("is off when no trust bundle is configured", async () => {
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }); // audience but NO bundle
+    expect(spiffeEnabled()).toBe(false);
+  });
+
+  it("is off when no trust domain is configured (federation-bundle safety)", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD }, k.jwk); // bundle + audience, NO trust domain
+    expect(spiffeEnabled()).toBe(false);
+    expect(await verifySpiffeSvid(await svid(k.priv, k.kid, { aud: AUD }))).toBeNull();
+  });
+
+  it("fails closed at config parse on a malformed SPIFFE_JWKS_URL", () => {
+    expect(() =>
+      parseConfig({ spiffeAudience: AUD, spiffeTrustDomain: TD, spiffeJwksUrl: "not-a-url" }),
+    ).toThrow();
+  });
+
+  it("returns null for undefined input", async () => {
+    const k = await trustDomainKey();
+    await configure({ spiffeAudience: AUD, spiffeTrustDomain: TD }, k.jwk);
+    expect(await verifySpiffeSvid(undefined)).toBeNull();
+  });
+});

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -237,6 +237,25 @@ export const ConfigSchema = z.object({
    *  JWKS verifiers (AgentLens, Lore) can pin the issuer. */
   agentTokenIssuer: z.string().optional(),
 
+  // ─── External SPIFFE/WIMSE workload identity (#41) ──────────────────
+  /** Accept SPIFFE JWT-SVIDs whose audience equals this value. REQUIRED to
+   *  enable SPIFFE verification (the spec mandates audience validation). */
+  spiffeAudience: z.string().optional(),
+  /** Trust domain to pin SPIFFE IDs to, e.g. "example.org" → only
+   *  `spiffe://example.org/...` subjects are accepted. REQUIRED to enable SPIFFE
+   *  (a multi-domain/federation bundle must not authenticate an unexpected
+   *  domain as a fully-verified principal). */
+  spiffeTrustDomain: z.string().optional(),
+  /** URL of the SPIFFE trust bundle (a JWKS) for verifying SVID signatures.
+   *  Validated as a URL so a typo fails closed at startup, not per-request. */
+  spiffeJwksUrl: z.string().url().optional(),
+  /** Inline SPIFFE trust bundle as JWKS JSON (alternative to SPIFFE_JWKS_URL,
+   *  e.g. air-gapped). */
+  spiffeTrustBundle: z.string().optional(),
+  /** Optional max SVID age (seconds, checked against `iat`) — bounds acceptance
+   *  even if a trust domain mis-issues a long-lived SVID. Unset = only `exp`. */
+  spiffeMaxSvidAge: z.coerce.number().int().min(1).optional(),
+
   // ─── Per-agent spend / budgets (#13) ────────────────────────────────
   /** AgentLens base URL — source of per-agent spend telemetry. Unset = spend
    *  reads disabled. */
@@ -352,6 +371,11 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   AGENT_TOKEN_VERIFY_KEYS: "agentTokenVerifyKeys",
   AGENT_TOKEN_AUDIENCE: "agentTokenAudience",
   AGENT_TOKEN_ISSUER: "agentTokenIssuer",
+  SPIFFE_AUDIENCE: "spiffeAudience",
+  SPIFFE_TRUST_DOMAIN: "spiffeTrustDomain",
+  SPIFFE_JWKS_URL: "spiffeJwksUrl",
+  SPIFFE_TRUST_BUNDLE: "spiffeTrustBundle",
+  SPIFFE_MAX_SVID_AGE: "spiffeMaxSvidAge",
 };
 
 // ============================================================================
@@ -505,6 +529,16 @@ export function validateProductionConfig(config: Config): string[] {
     warnings.push(
       "AGENT_TOKEN_ISSUER has no effect without AGENT_TOKEN_SIGNING_KEY " +
         "(the iss claim is only minted on the RS256 path)",
+    );
+  }
+
+  // SPIFFE needs audience + trust domain + a bundle; surface a partial config so
+  // it isn't silently disabled.
+  const spiffeBundle = config.spiffeJwksUrl || config.spiffeTrustBundle;
+  if ((config.spiffeAudience || spiffeBundle) && !(config.spiffeAudience && config.spiffeTrustDomain && spiffeBundle)) {
+    warnings.push(
+      "SPIFFE verification is DISABLED: it requires SPIFFE_AUDIENCE + " +
+        "SPIFFE_TRUST_DOMAIN + (SPIFFE_JWKS_URL or SPIFFE_TRUST_BUNDLE) all set",
     );
   }
 

--- a/packages/server/src/lib/agent-tokens.ts
+++ b/packages/server/src/lib/agent-tokens.ts
@@ -18,6 +18,7 @@ import {
   getJwksVerifier,
   getAgentTokenAudience,
 } from "./agent-token-keys.js";
+import { verifySpiffeSvid } from "./spiffe.js";
 
 export const AGENT_TOKEN_TYP = "agent";
 
@@ -113,6 +114,12 @@ export async function resolveVerifiedAgentId(
       const live = await getAgentIfActive(tokenAgentId);
       if (live) return live;
     }
+    // External SPIFFE/WIMSE workload identity (#41): the same X-Agent-Token slot
+    // may carry a SPIFFE JWT-SVID. It is verified against the trust bundle (a
+    // DIFFERENT key set than our own tokens) and the SPIFFE ID IS the verified
+    // principal — externally attested, so no agents-table liveness lookup.
+    const spiffeId = await verifySpiffeSvid(creds.agentToken);
+    if (spiffeId) return spiffeId;
   }
   return (await verifyAgentCredential(creds.agentId, creds.agentSecret))?.id ?? null;
 }

--- a/packages/server/src/lib/spiffe.ts
+++ b/packages/server/src/lib/spiffe.ts
@@ -1,0 +1,124 @@
+// @agentgate/server — Accept an external SPIFFE JWT-SVID as a verified principal (#41).
+//
+// Enterprises that already run a SPIFFE/SPIRE (or WIMSE) workload-identity plane
+// can present a JWT-SVID instead of minting an AgentGate agent token. AgentGate
+// verifies the SVID against the trust domain's published keys (the trust bundle,
+// a JWKS) and resolves it to the SAME verified-principal slot the agent-token
+// path uses — the principal id is the SPIFFE ID itself (e.g.
+// `spiffe://example.org/agent/checkout`). SPIFFE IDs are externally attested by
+// the platform, so they are NOT required to exist in AgentGate's `agents` table
+// (binding a SPIFFE id to a registered agt_* for budgets/policies is a future
+// add — see docs/agent-identity.md).
+//
+// Per the SPIFFE JWT-SVID spec the verifier MUST validate the audience, so the
+// feature is OFF unless BOTH a trust-bundle source AND SPIFFE_AUDIENCE are set.
+// WIMSE Workload Identity Tokens are the same JWS-over-JWKS shape and verify
+// through this path once their issuer's keys are configured as the bundle.
+
+import { jwtVerify, createRemoteJWKSet, createLocalJWKSet, type JWK } from "jose";
+
+import { getConfig } from "../config.js";
+
+// SPIFFE JWT-SVIDs are signed with an asymmetric alg; never accept HS*/none.
+const SPIFFE_ALGS = ["RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512", "EdDSA"];
+
+type Verifier = ReturnType<typeof createRemoteJWKSet> | ReturnType<typeof createLocalJWKSet>;
+
+interface SpiffeState {
+  verifier: Verifier | null;
+  audience: string | null;
+  trustDomain: string | null;
+  maxTokenAge: number | null;
+}
+
+const DISABLED: SpiffeState = { verifier: null, audience: null, trustDomain: null, maxTokenAge: null };
+
+let cache: SpiffeState | null = null;
+
+function build(): SpiffeState {
+  const cfg = getConfig();
+  const audience = cfg.spiffeAudience?.trim() || null;
+  const trustDomain = cfg.spiffeTrustDomain?.trim() || null;
+  const url = cfg.spiffeJwksUrl?.trim();
+  const inline = cfg.spiffeTrustBundle?.trim();
+  const maxTokenAge = cfg.spiffeMaxSvidAge ?? null;
+
+  // Both are mandatory: audience per the SPIFFE spec; trust domain so a
+  // multi-domain/federation bundle can't authenticate an unexpected domain as a
+  // fully-verified principal. Missing either → feature off.
+  if (!audience || !trustDomain) return DISABLED;
+
+  let verifier: Verifier | null = null;
+  if (url) {
+    // URL is operator config (not attacker-controlled) → no SSRF. Pin fetch
+    // behaviour so a slow trust-bundle endpoint can't stall request handling.
+    // new URL can throw on a malformed value — fail closed (disabled), never
+    // let it propagate to the request hot path.
+    try {
+      verifier = createRemoteJWKSet(new URL(url), {
+        timeoutDuration: 2500,
+        cooldownDuration: 30_000,
+        cacheMaxAge: 600_000,
+      });
+    } catch {
+      console.error("Warning: SPIFFE_JWKS_URL is not a valid URL; SPIFFE verification disabled");
+    }
+  } else if (inline) {
+    try {
+      const parsed = JSON.parse(inline) as { keys?: JWK[] };
+      if (Array.isArray(parsed.keys) && parsed.keys.length > 0) {
+        verifier = createLocalJWKSet(parsed as { keys: JWK[] });
+      } else {
+        console.error("Warning: SPIFFE_TRUST_BUNDLE has no keys; SPIFFE verification disabled");
+      }
+    } catch {
+      console.error("Warning: SPIFFE_TRUST_BUNDLE is not valid JWKS JSON; SPIFFE verification disabled");
+    }
+  }
+
+  return verifier ? { verifier, audience, trustDomain, maxTokenAge } : DISABLED;
+}
+
+function state(): SpiffeState {
+  return (cache ??= build());
+}
+
+/** Drop the cached SPIFFE verifier (tests + after a config change). */
+export function __resetSpiffeCache(): void {
+  cache = null;
+}
+
+/** True when SPIFFE SVID verification is configured (a trust bundle AND an audience). */
+export function spiffeEnabled(): boolean {
+  return state().verifier !== null;
+}
+
+/**
+ * Verify a token AS a SPIFFE JWT-SVID. Returns the SPIFFE ID (`sub`, e.g.
+ * `spiffe://td/workload`) iff: the signature is valid against the trust bundle,
+ * the algorithm is asymmetric, the audience matches SPIFFE_AUDIENCE, `exp` (and
+ * the optional max age) are valid, and `sub` is `spiffe://<trust-domain>/<path>`
+ * with a non-empty workload path. Otherwise null. Never throws.
+ */
+export async function verifySpiffeSvid(token: string | undefined | null): Promise<string | null> {
+  if (!token) return null;
+  const { verifier, audience, trustDomain, maxTokenAge } = state();
+  if (!verifier || !audience || !trustDomain) return null;
+
+  try {
+    const { payload } = await jwtVerify(token, verifier, {
+      algorithms: SPIFFE_ALGS,
+      audience, // SPIFFE spec: audience validation is mandatory.
+      ...(maxTokenAge ? { maxTokenAge } : {}),
+    });
+    const sub = payload.sub;
+    if (typeof sub !== "string") return null;
+    // Pin to the expected trust domain (the trailing slash blocks suffix attacks
+    // like spiffe://example.org.evil/…) AND require a non-empty workload path.
+    const prefix = `spiffe://${trustDomain}/`;
+    if (!sub.startsWith(prefix) || sub.length <= prefix.length) return null;
+    return sub;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #41.

## What

Accept an external **SPIFFE JWT-SVID** (and WIMSE-shaped workload token) on `X-Agent-Token` as a verified principal — so an enterprise already running SPIFFE/SPIRE can use AgentGate without minting AgentGate tokens. The SVID resolves to the **SPIFFE ID itself** as the verified principal. Builds directly on the #40 JWKS verifier; purely additive (off unless configured).

## How

- **`lib/spiffe.ts`** — `verifySpiffeSvid` runs `jose.jwtVerify` against the trust bundle (`SPIFFE_JWKS_URL` remote, or inline `SPIFFE_TRUST_BUNDLE`), **pinned to asymmetric algs** (RS*/PS*/ES*/EdDSA — never HS/none), with the **mandatory audience check** (`SPIFFE_AUDIENCE`, per the SPIFFE JWT-SVID spec), optional `SPIFFE_MAX_SVID_AGE`, and `sub` pinned to `spiffe://<SPIFFE_TRUST_DOMAIN>/<non-empty path>`. Fail-safe — any error returns null.
- **`resolveVerifiedAgentId`** — after the AgentGate-token path yields no live agent, a valid SVID resolves to its SPIFFE ID. Externally attested → **no `agents`-table liveness lookup**. Gated off in `api-key-only` mode (same as the token path).
- **Enable** requires `SPIFFE_AUDIENCE` + `SPIFFE_TRUST_DOMAIN` + a bundle; a partial config logs a "DISABLED" warning. `SPIFFE_JWKS_URL` is URL-validated so a typo fails closed at startup.

## Security review (find→verify, folded in)

One confirmed **fix-now**: `build()` ran `new URL(malformed)` outside a try/catch and the URL wasn't validated, so an operator typo in `SPIFFE_JWKS_URL` could throw a **500 on every request hot path** (and the failure wasn't memoized) — violating the "never throws" contract. Fixed: wrapped construction fail-safe **and** `z.string().url()` at config parse. Also folded:
- **Require `SPIFFE_TRUST_DOMAIN`** to enable — closes the federation-bundle hole where a multi-domain bundle would authenticate an unexpected domain.
- **Non-empty workload path** required (rejects bare `spiffe://td/`); the trailing-slash trust-domain pin blocks suffix attacks (`spiffe://example.org.evil/…`).
- Optional **max-SVID-age** cap; documented that SPIFFE principals **bypass per-agent budgets/policies** (not in the agents table) until ID→`agt_*` binding lands.

## Tests / validation

- `spiffe.test.ts` (14): valid SVID, aud array, missing/wrong aud, wrong trust domain, non-spiffe sub, key-not-in-bundle, HS256 reject, bare-root reject, max-age reject, disabled states, malformed-URL fail-closed at parse.
- `agent-tokens.test.ts` (+2): `resolveVerifiedAgentId` resolves a SPIFFE SVID; ignores it in `api-key-only`.
- Full server suite **770/771** (the 1 is the pre-existing `rate-limiter` Redis flake), `tsc` clean, `pnpm build` + `docs:build` green.

## Deferred (documented)

X.509-SVID (Workload API / mTLS) and **binding a SPIFFE ID to a registered `agt_*`** for budget/policy scoping — noted in `docs/agent-identity.md` Future work.
