### PR TITLE
feat(requests): per-agent eval gate (agenteval#7, slice 2)

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -125,9 +125,14 @@ When a request arrives, the initial decision follows a fixed **precedence**
 (highest first):
 
 1. **Budget** — an over-budget agent is **denied** (`decidedByType: budget_limiter`).
-2. **Override** — a matching dynamic override forces the outcome: `deny` →
+2. **Eval gate** — an agent whose latest eval pass-rate (read from AgentLens) is
+   below `AGENT_EVAL_MIN_PASS_RATE` is **denied** (`decidedByType: eval_gate`).
+   Opt-in via `AGENT_EVAL_GATE`; **fails open** (an un-evaluated agent or a
+   telemetry outage is allowed). Requires `AGENTLENS_URL` + `AGENTGATE_SERVICE_TOKEN`
+   and eval evidence federated from agenteval (agentlens#85).
+3. **Override** — a matching dynamic override forces the outcome: `deny` →
    denied, otherwise → pending human review (`override`).
-3. **Policy** — static policy rules decide allow / deny / route-to-human (`policy`).
+4. **Policy** — static policy rules decide allow / deny / route-to-human (`policy`).
 
 The chosen layer is recorded as `decidedByType` on the audit row, alongside the
 verified agent id and (for human decisions) the deciding user — so every

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -117,7 +117,7 @@ export interface RequestDecidedEvent
     action: string;
     status: Extract<ApprovalStatus, "approved" | "denied">;
     decidedBy: string;
-    decidedByType: "human" | "agent" | "policy" | "budget_limiter" | "override";
+    decidedByType: "human" | "agent" | "policy" | "budget_limiter" | "eval_gate" | "override";
     reason?: string;
     /** Time from creation to decision in milliseconds */
     decisionTimeMs: number;

--- a/packages/server/src/__tests__/agent-eval.test.ts
+++ b/packages/server/src/__tests__/agent-eval.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Per-agent eval gate read + verdict (#7). checkAgentEval reads an agent's latest
+ * eval pass-rate from AgentLens and decides allow/deny; it must FAIL OPEN.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { checkAgentEval, clearEvalCache } from "../lib/agent-eval.js";
+import { parseConfig, setConfig, resetConfig } from "../config.js";
+
+const LENS = { agentlensUrl: "https://lens.example", agentgateServiceToken: "svc", agentEvalMinPassRate: 0.8 };
+
+function mockStatus(resp: Record<string, unknown>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, status: 200, json: async () => resp }) as Response),
+  );
+}
+
+beforeEach(() => {
+  clearEvalCache();
+  setConfig(parseConfig(LENS));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetConfig();
+});
+
+describe("checkAgentEval (#7)", () => {
+  it("allows when the latest pass-rate is at/above the minimum", async () => {
+    mockStatus({ found: true, passRate: 0.9 });
+    const v = await checkAgentEval("agt_a", "default");
+    expect(v.allowed).toBe(true);
+    expect(v.passRate).toBe(0.9);
+    expect(v.minPassRate).toBe(0.8);
+  });
+
+  it("denies when the latest pass-rate is below the minimum", async () => {
+    mockStatus({ found: true, passRate: 0.5 });
+    expect((await checkAgentEval("agt_a", "default")).allowed).toBe(false);
+  });
+
+  it("allows an agent with no eval evidence yet (found:false)", async () => {
+    mockStatus({ found: false });
+    expect((await checkAgentEval("agt_a", "default")).allowed).toBe(true);
+  });
+
+  it("fails open when AgentLens is not configured", async () => {
+    setConfig(parseConfig({ agentEvalMinPassRate: 0.8 })); // no url/token
+    clearEvalCache();
+    expect((await checkAgentEval("agt_a", "default")).allowed).toBe(true);
+  });
+
+  it("fails open when the eval-status read errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("network down"); }));
+    expect((await checkAgentEval("agt_a", "default")).allowed).toBe(true);
+  });
+
+  it("respects a custom minimum pass-rate", async () => {
+    setConfig(parseConfig({ ...LENS, agentEvalMinPassRate: 0.4 }));
+    clearEvalCache();
+    mockStatus({ found: true, passRate: 0.5 });
+    expect((await checkAgentEval("agt_a", "default")).allowed).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/request-decision.test.ts
+++ b/packages/server/src/__tests__/request-decision.test.ts
@@ -77,4 +77,34 @@ describe("decideInitialStatus precedence", () => {
     expect(d.decidedBy).toBeNull();
     expect(d.decidedAt).toBeNull();
   });
+
+  // ── Eval gate (#7) ──────────────────────────────────────
+  it("eval gate denies, beating override + policy", () => {
+    const d = decideInitialStatus({
+      budgetReason: null,
+      evalReason: "Eval gate: pass-rate 0.50 below required 0.80",
+      overrideMatch: override,
+      policyDecision: approve,
+      now: NOW,
+    });
+    expect(d.status).toBe("denied");
+    expect(d.decidedBy).toBe("eval_gate");
+    expect(d.decidedByType).toBe("eval_gate");
+    expect(d.decisionReason).toContain("Eval gate");
+  });
+
+  it("budget deny outranks the eval gate (budget precedence preserved)", () => {
+    const d = decideInitialStatus({
+      budgetReason: "over budget",
+      evalReason: "Eval gate: below threshold",
+      overrideMatch: null,
+      policyDecision: approve,
+      now: NOW,
+    });
+    expect(d.decidedByType).toBe("budget_limiter");
+  });
+
+  it("no evalReason → unchanged behavior (gate off / agent passes)", () => {
+    expect(decide(null, approve).status).toBe("approved"); // evalReason omitted entirely
+  });
 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -278,6 +278,15 @@ export const ConfigSchema = z.object({
     .union([z.boolean(), z.string()])
     .transform((val) => (typeof val === "boolean" ? val : ["true", "1", "yes"].includes(val.toLowerCase())))
     .default(false),
+  /** Per-agent eval gate (#7): deny requests from an agent whose latest eval
+   *  pass-rate (read from AgentLens) is below agentEvalMinPassRate. Default off
+   *  — ships dark until an operator opts in. Fails open. */
+  agentEvalGate: z
+    .union([z.boolean(), z.string()])
+    .transform((val) => (typeof val === "boolean" ? val : ["true", "1", "yes"].includes(val.toLowerCase())))
+    .default(false),
+  /** Minimum eval pass-rate (0..1) an agent must meet when AGENT_EVAL_GATE is on. */
+  agentEvalMinPassRate: z.coerce.number().min(0).max(1).default(0.8),
 
   // Metrics
   /** Enable Prometheus metrics endpoint (default true) */
@@ -366,6 +375,8 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   SPEND_READ_TIMEOUT_MS: "spendReadTimeoutMs",
   AGENT_BUDGET_ENFORCEMENT: "agentBudgetEnforcement",
   AGENT_BUDGET_ALERTS: "agentBudgetAlerts",
+  AGENT_EVAL_GATE: "agentEvalGate",
+  AGENT_EVAL_MIN_PASS_RATE: "agentEvalMinPassRate",
   AGENT_TOKEN_SIGNING_KEY: "agentTokenSigningKey",
   AGENT_TOKEN_SIGNING_KID: "agentTokenSigningKid",
   AGENT_TOKEN_VERIFY_KEYS: "agentTokenVerifyKeys",

--- a/packages/server/src/lib/agent-eval.ts
+++ b/packages/server/src/lib/agent-eval.ts
@@ -1,0 +1,103 @@
+// @agentgate/server — Per-agent eval gate (#7).
+//
+// Reads an agent's latest eval pass-rate from AgentLens
+// (GET /api/internal/agent-eval-status; populated by the agenteval→lens
+// federation, agentlens#85) and gates the NEXT request when it's below the
+// configured threshold. Like the budget gate this is a SOFT guardrail and
+// FAILS OPEN: if eval status can't be read (AgentLens unconfigured/unreachable)
+// or the agent has no eval evidence yet, the request is allowed — never blocked
+// on a telemetry outage or an un-evaluated agent. Default-off via AGENT_EVAL_GATE.
+
+import { AgentGateHttpClient } from "@agentgate/core";
+
+import { getConfig } from "../config.js";
+import { getLogger } from "./logger.js";
+
+/** Thrown when AGENTLENS_URL / AGENTGATE_SERVICE_TOKEN are not configured. */
+export class EvalNotConfiguredError extends Error {
+  constructor() {
+    super("Eval gate not configured (set AGENTLENS_URL and AGENTGATE_SERVICE_TOKEN)");
+    this.name = "EvalNotConfiguredError";
+  }
+}
+
+interface EvalStatusResponse {
+  found?: boolean;
+  passRate?: number | null;
+  passedCases?: number;
+  totalCases?: number;
+  runId?: string;
+}
+
+export interface EvalStatus {
+  found: boolean;
+  passRate: number | null;
+}
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { status: EvalStatus; at: number }>();
+
+/** Clear the eval-status cache (testing). */
+export function clearEvalCache(): void {
+  cache.clear();
+}
+
+/**
+ * Fetch one agent's latest completed eval status from AgentLens, cached briefly.
+ * Throws EvalNotConfiguredError when AgentLens isn't configured; propagates
+ * network/upstream errors to the caller (checkAgentEval fails open on them).
+ */
+export async function fetchAgentEvalStatus(
+  agentId: string,
+  tenantId: string,
+  maxAgeMs = CACHE_TTL_MS,
+): Promise<EvalStatus> {
+  const config = getConfig();
+  if (!config.agentlensUrl || !config.agentgateServiceToken) {
+    throw new EvalNotConfiguredError();
+  }
+  const key = `${tenantId}:${agentId}`;
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < maxAgeMs) return hit.status;
+
+  const client = new AgentGateHttpClient(config.agentlensUrl, config.agentgateServiceToken, config.spendReadTimeoutMs);
+  const res = await client.request<EvalStatusResponse>(
+    "GET",
+    `/api/internal/agent-eval-status?agentId=${encodeURIComponent(agentId)}&tenantId=${encodeURIComponent(tenantId)}`,
+  );
+  const status: EvalStatus = {
+    found: res?.found === true,
+    passRate: typeof res?.passRate === "number" ? res.passRate : null,
+  };
+  cache.set(key, { status, at: Date.now() });
+  return status;
+}
+
+export interface EvalVerdict {
+  allowed: boolean;
+  /** The agent's latest pass-rate, or null when none/unknown. */
+  passRate: number | null;
+  /** The configured minimum required pass-rate. */
+  minPassRate: number;
+}
+
+/**
+ * Whether `agentId` meets the minimum eval pass-rate. An agent with NO eval
+ * evidence (never evaluated) is allowed — the gate blocks demonstrably-failing
+ * agents, not un-evaluated ones. Fails open (allowed) when status can't be read.
+ */
+export async function checkAgentEval(agentId: string, tenantId: string): Promise<EvalVerdict> {
+  const minPassRate = getConfig().agentEvalMinPassRate;
+  try {
+    const status = await fetchAgentEvalStatus(agentId, tenantId);
+    if (!status.found || status.passRate === null) {
+      return { allowed: true, passRate: status.passRate, minPassRate };
+    }
+    return { allowed: status.passRate >= minPassRate, passRate: status.passRate, minPassRate };
+  } catch (err) {
+    if (!(err instanceof EvalNotConfiguredError)) {
+      getLogger().warn({ err, agentId }, "agent eval check failed; allowing (fail-open)");
+    }
+    return { allowed: true, passRate: null, minPassRate };
+  }
+}

--- a/packages/server/src/lib/request-decision.ts
+++ b/packages/server/src/lib/request-decision.ts
@@ -1,16 +1,17 @@
 // @agentgate/server — Initial decision for a new approval request.
 //
 // Precedence (highest first): a per-agent budget overage (#13) denies outright,
-// then a dynamic override forces human review (pending), then static policy
-// auto-approve/deny. Anything else stays pending. Extracted as a pure function
-// so the precedence is unit-testable without driving the whole request route.
+// then the per-agent eval gate (#7) denies outright, then a dynamic override
+// forces human review (pending), then static policy auto-approve/deny. Anything
+// else stays pending. Extracted as a pure function so the precedence is
+// unit-testable without driving the whole request route.
 
 import type { PolicyDecision } from "@agentgate/core";
 
 export interface InitialDecision {
   status: "pending" | "approved" | "denied";
   decidedBy: string | null;
-  decidedByType: "policy" | "budget_limiter" | "override";
+  decidedByType: "policy" | "budget_limiter" | "eval_gate" | "override";
   decidedAt: Date | null;
   decisionReason: string | null;
 }
@@ -18,6 +19,8 @@ export interface InitialDecision {
 export function decideInitialStatus(input: {
   /** Non-null when the verified agent is over its budget; the reason string. */
   budgetReason: string | null;
+  /** Non-null when the verified agent fails the eval gate (#7); the reason string. */
+  evalReason?: string | null;
   /** A matching dynamic override, or null. `action` "deny" hard-denies; anything
    *  else (require_approval) forces human review. */
   overrideMatch: { action?: string; reason?: string | null } | null;
@@ -25,7 +28,7 @@ export function decideInitialStatus(input: {
   /** Decision timestamp, stamped on auto-decided (approved/denied) outcomes. */
   now: Date;
 }): InitialDecision {
-  const { budgetReason, overrideMatch, policyDecision, now } = input;
+  const { budgetReason, evalReason, overrideMatch, policyDecision, now } = input;
 
   if (budgetReason) {
     return {
@@ -34,6 +37,15 @@ export function decideInitialStatus(input: {
       decidedByType: "budget_limiter",
       decidedAt: now,
       decisionReason: budgetReason,
+    };
+  }
+  if (evalReason) {
+    return {
+      status: "denied",
+      decidedBy: "eval_gate",
+      decidedByType: "eval_gate",
+      decidedAt: now,
+      decisionReason: evalReason,
     };
   }
   if (overrideMatch) {

--- a/packages/server/src/routes/audit.ts
+++ b/packages/server/src/routes/audit.ts
@@ -77,7 +77,7 @@ auditRouter.get("/", async (c) => {
 
   // decidedByType (#22): lives in the decision audit event's details JSON
   // (set by the auto-decision / human-decide path). Match it backend-agnostically.
-  const validDecidedByTypes = ["policy", "human", "agent", "budget_limiter", "override"];
+  const validDecidedByTypes = ["policy", "human", "agent", "budget_limiter", "eval_gate", "override"];
   if (decidedByType && validDecidedByTypes.includes(decidedByType)) {
     auditConditions.push(
       getDialect() === "postgres"

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -18,6 +18,7 @@ import { logAuditEvent } from "../lib/audit.js";
 import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
 import { resolveVerifiedAgentId, resolveEffectiveAgentId } from "../lib/agent-tokens.js";
 import { checkAgentBudget } from "../lib/agent-budget.js";
+import { checkAgentEval } from "../lib/agent-eval.js";
 import { maybeAlertBudgetThreshold } from "../lib/budget-alerts.js";
 import { decideInitialStatus } from "../lib/request-decision.js";
 import { getConfig } from "../config.js";
@@ -139,7 +140,7 @@ async function handleAutoDecision(opts: {
   action: string;
   status: "approved" | "denied";
   decidedBy: string;
-  decidedByType: "policy" | "human" | "agent" | "budget_limiter" | "override";
+  decidedByType: "policy" | "human" | "agent" | "budget_limiter" | "eval_gate" | "override";
   decisionReason: string | null;
   requestSnapshot: Record<string, unknown>;
   channels?: string[];
@@ -277,6 +278,19 @@ requestsRouter.post("/", async (c) => {
     }
   }
 
+  // Per-agent eval gate (#7): deny when the verified agent's latest eval pass-rate
+  // (read from AgentLens) is below the configured minimum. Opt-in (AGENT_EVAL_GATE);
+  // checkAgentEval fails open, so a telemetry outage / un-evaluated agent allows.
+  let evalReason: string | null = null;
+  // Skip the AgentLens round-trip when budget already denies (budget outranks eval).
+  if (effectiveAgentId && cfg.agentEvalGate && !budgetReason) {
+    const tenantId = c.get("auth")?.tenantId ?? "default";
+    const verdict = await checkAgentEval(effectiveAgentId, tenantId);
+    if (!verdict.allowed) {
+      evalReason = `Eval gate: pass-rate ${(verdict.passRate ?? 0).toFixed(2)} below required ${verdict.minPassRate.toFixed(2)}`;
+    }
+  }
+
   // Check overrides BEFORE static policies, keyed on the VERIFIED agent id.
   let overrideMatch: Awaited<ReturnType<typeof checkOverrides>> = null;
   if (effectiveAgentId) {
@@ -292,6 +306,7 @@ requestsRouter.post("/", async (c) => {
   // Determine initial status — budget deny > override > policy (see helper).
   const { status, decidedBy, decidedByType, decidedAt, decisionReason } = decideInitialStatus({
     budgetReason,
+    evalReason,
     overrideMatch,
     policyDecision,
     now,
@@ -328,7 +343,7 @@ requestsRouter.post("/", async (c) => {
     // Who actually made the request, cryptographically verified (vs the
     // unverified context.agentId claim).
     verifiedAgentId: effectiveAgentId,
-    // What kind of decision was applied (policy | budget_limiter | override);
+    // What kind of decision was applied (policy | budget_limiter | eval_gate | override);
     // makes the audit filterable by decidedByType (#22).
     decidedByType,
   });


### PR DESCRIPTION
**Closes agentkitai/agenteval#7** (slice 2 of 2; slice 1 = agentlens #105, merged).

**What:** AgentGate denies an agent's next request when its latest eval pass-rate (read from AgentLens) is below `AGENT_EVAL_MIN_PASS_RATE` — closing the governance loop **agenteval evidence → identity → enforcement**. Mirrors the per-agent budget gate.

**How:**
- `lib/agent-eval.ts` — `fetchAgentEvalStatus` (cached, service-token) + `checkAgentEval`. **SOFT + FAILS OPEN**: an un-evaluated agent (`found:false`) or a telemetry outage/unconfigured AgentLens is **allowed**, never blocked.
- `request-decision.ts` — `evalReason` precedence (**budget > eval > override > policy**); new `decidedByType: "eval_gate"` added to all four union/allowlist sites (core events, request-decision, requests route, audit filter).
- `requests.ts` — opt-in via `AGENT_EVAL_GATE` (**default OFF → behavior byte-for-byte unchanged**); skips the AgentLens round-trip when budget already denies.
- config: `AGENT_EVAL_GATE`, `AGENT_EVAL_MIN_PASS_RATE` (default 0.8). `docs/governance.md` precedence updated.

**Tests:** `agent-eval.test.ts` (allow≥min, deny<min, allow-no-evidence, fail-open unconfigured/error, custom min) + eval precedence cases in `request-decision.test.ts`. Full server suite green (the 1 fail is the pre-existing rate-limiter Redis flake). Adversarial review (default-off safety, fail-open, precedence, all union sites) clean — 0 fix-now; folded budget-short-circuit + comment fixes.

Per the budget-gate precedent, the pure fns are unit-tested rather than the route (the integration harness is a mock).