### PR TITLE
feat(mcp): inline approval — long-poll the decision (#42)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -232,12 +232,23 @@ Agency)**, queryable by tool name. The gate **fails open** (allows) on a
 network/auth error or when no agent identity is present. Manage overrides with
 `agentgate override …` (see the CLI docs) or `POST /api/overrides`.
 
+### Inline approval (long-poll)
+
+By default a `require_approval` gate returns a **pending handle** immediately and
+the agent polls `agentgate_get` for the decision. Set `AGENTGATE_APPROVAL_WAIT_MS`
+> 0 to instead **wait inline**: the tool call long-polls the decision and resolves
+in one round-trip — **approved** → the tool runs; **denied/expired** → an error
+result; still pending at the timeout → the usual pending handle (so a slow
+approver never blocks indefinitely). Off (`0`) by default — behavior unchanged.
+
 ## Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `AGENTGATE_URL` | Yes | AgentGate server URL |
 | `AGENTGATE_API_KEY` | Yes | API key for authentication |
+| `AGENTGATE_APPROVAL_WAIT_MS` | No | Inline-approval long-poll budget (ms). `0` (default) = return a pending handle immediately. |
+| `AGENTGATE_APPROVAL_POLL_MS` | No | Poll interval (ms) while waiting (default `2000`). |
 
 ## Running Standalone
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -9,11 +9,13 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { ApiConfig } from './types.js';
-import { toolDefinitions, handleToolCall, authorizeTool, guardrailBlockResult } from './tools.js';
+import { toolDefinitions, executeGatedToolCall } from './tools.js';
 
 const config: ApiConfig = {
   baseUrl: process.env.AGENTGATE_URL ?? 'http://localhost:3000',
   apiKey: process.env.AGENTGATE_API_KEY ?? '',
+  approvalWaitMs: Number(process.env.AGENTGATE_APPROVAL_WAIT_MS ?? 0) || 0,
+  approvalPollMs: Number(process.env.AGENTGATE_APPROVAL_POLL_MS ?? 2000) || 2000,
 };
 
 const server = new Server(
@@ -26,14 +28,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [...toolDefinitions],
 }));
 
-// Handle tool calls — gate on per-agent guardrails (issue #14) before executing.
+// Handle tool calls — gate on per-agent guardrails (#14), optionally waiting
+// inline for an approval decision when AGENTGATE_APPROVAL_WAIT_MS > 0 (#42).
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
-  const verdict = await authorizeTool(config, name, args ?? {});
-  // deny → synchronous error; requires_approval → pending; else run the tool.
-  const blocked = guardrailBlockResult(verdict);
-  if (blocked) return blocked;
-  return handleToolCall(config, name, args ?? {});
+  return executeGatedToolCall(config, name, args ?? {});
 });
 
 // Start server

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -7,6 +7,8 @@ import {
   guardrailBlockResult,
   handleToolCall,
   authorizeTool,
+  waitForApproval,
+  executeGatedToolCall,
   toolDefinitions,
   normalizeDecidedBy,
 } from './tools.js';
@@ -569,5 +571,73 @@ describe('authorizeTool (MCP guardrail, #14)', () => {
   it('fails OPEN (returns null) on a network/auth error', async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('') });
     expect(await authorizeTool(config, 'file.read', {})).toBeNull();
+  });
+});
+
+describe('inline approval — waitForApproval + executeGatedToolCall (#42)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const config: ApiConfig = { baseUrl: 'http://localhost:3000', apiKey: 'k', approvalWaitMs: 100, approvalPollMs: 5 };
+
+  beforeEach(() => { fetchMock = vi.fn(); vi.stubGlobal('fetch', fetchMock); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  const jsonRes = (data: unknown) => ({ ok: true, status: 200, json: () => Promise.resolve(data) });
+
+  /** Route fetch: authorize → verdict; poll → next status; anything else → tool run. */
+  function routes(opts: { verdict?: string; pollStatuses?: string[] }) {
+    const verdict = opts.verdict ?? 'requires_approval';
+    const statuses = opts.pollStatuses ?? ['pending'];
+    let i = 0;
+    fetchMock.mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u.endsWith('/api/mcp/authorize')) return jsonRes({ decision: verdict, requestId: 'req_1' });
+      if (u.includes('/api/requests/req_1')) return jsonRes({ id: 'req_1', status: statuses[Math.min(i++, statuses.length - 1)] });
+      return jsonRes({ id: 'ran', ok: true });
+    });
+  }
+
+  it('waitForApproval returns the terminal status once decided', async () => {
+    routes({ pollStatuses: ['pending', 'approved'] });
+    expect(await waitForApproval(config, 'req_1', { waitMs: 100, pollMs: 5 })).toBe('approved');
+  });
+
+  it('waitForApproval returns pending on timeout', async () => {
+    routes({ pollStatuses: ['pending'] });
+    expect(await waitForApproval(config, 'req_1', { waitMs: 20, pollMs: 5 })).toBe('pending');
+  });
+
+  it('approved → runs the tool', async () => {
+    routes({ pollStatuses: ['approved'] });
+    const r = await executeGatedToolCall(config, 'agentgate_request', { action: 'send', params: {} });
+    expect(r.isError).toBeUndefined();
+    expect(JSON.stringify(r)).toContain('ran');
+  });
+
+  it('denied → isError', async () => {
+    routes({ pollStatuses: ['denied'] });
+    const r = await executeGatedToolCall(config, 'agentgate_request', { action: 'send', params: {} });
+    expect(r.isError).toBe(true);
+    expect(JSON.stringify(r)).toContain('denied');
+  });
+
+  it('timeout → pending handle (non-error)', async () => {
+    routes({ pollStatuses: ['pending'] });
+    const r = await executeGatedToolCall({ ...config, approvalWaitMs: 20 }, 'agentgate_request', { action: 'send', params: {} });
+    expect(r.isError).toBeUndefined();
+    expect(JSON.stringify(r)).toContain('pending');
+  });
+
+  it('waitMs=0 (legacy) → pending handle immediately, never polls', async () => {
+    routes({ pollStatuses: ['approved'] });
+    const r = await executeGatedToolCall({ ...config, approvalWaitMs: 0 }, 'agentgate_request', { action: 'send', params: {} });
+    expect(JSON.stringify(r)).toContain('pending');
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes('/api/requests/req_1'))).toBe(false);
+  });
+
+  it('a deny verdict → isError without polling', async () => {
+    routes({ verdict: 'deny' });
+    const r = await executeGatedToolCall(config, 'agentgate_request', { action: 'send', params: {} });
+    expect(r.isError).toBe(true);
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes('/api/requests/req_1'))).toBe(false);
   });
 });

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -240,6 +240,66 @@ export function guardrailBlockResult(
 }
 
 /**
+ * Long-poll an approval request until it leaves `pending` or the budget runs out
+ * (#42). Returns the terminal status (`approved`/`denied`/`expired`) or `pending`
+ * on timeout. Transient read errors don't abort — they're retried until the
+ * deadline (the caller treats a final `pending` as "still waiting").
+ */
+export async function waitForApproval(
+  config: ApiConfig,
+  requestId: string,
+  opts: { waitMs: number; pollMs: number },
+): Promise<string> {
+  const deadline = Date.now() + opts.waitMs;
+  for (;;) {
+    let status: string | undefined;
+    try {
+      const res = (await apiCall(config, 'GET', `/api/requests/${requestId}`)) as { status?: string };
+      status = res?.status;
+    } catch {
+      // transient — keep polling until the deadline
+    }
+    if (status && status !== 'pending') return status;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return 'pending';
+    await new Promise((resolve) => setTimeout(resolve, Math.min(opts.pollMs, remaining)));
+  }
+}
+
+/**
+ * Authorize a tool call, optionally waiting inline for an approval decision
+ * (#42), then run or block it. With `approvalWaitMs` unset/0 this is the legacy
+ * flow (a `requires_approval` returns a pending handle immediately). With it >0,
+ * a `requires_approval` long-polls: approved → run the tool; denied/expired →
+ * error; still pending at timeout → the pending handle (unchanged shape).
+ */
+export async function executeGatedToolCall(
+  config: ApiConfig,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const verdict = await authorizeTool(config, name, args);
+  const waitMs = config.approvalWaitMs ?? 0;
+  if (verdict?.decision === 'requires_approval' && verdict.requestId && waitMs > 0) {
+    const status = await waitForApproval(config, verdict.requestId, {
+      waitMs,
+      pollMs: config.approvalPollMs ?? 2000,
+    });
+    if (status === 'approved') return handleToolCall(config, name, args);
+    if (status === 'denied' || status === 'expired') {
+      return {
+        ...formatResult({ status, requestId: verdict.requestId, message: `Tool call ${status} by AgentGate.` }),
+        isError: true,
+      };
+    }
+    // still pending after the budget — fall through to the pending handle below.
+  }
+  const blocked = guardrailBlockResult(verdict);
+  if (blocked) return blocked;
+  return handleToolCall(config, name, args);
+}
+
+/**
  * Handle agentgate_request tool
  */
 export async function handleRequest(

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -71,6 +71,11 @@ export interface GetAuditActorsArgs {
 export interface ApiConfig {
   baseUrl: string;
   apiKey: string;
+  /** Inline-approval long-poll budget (ms). 0 (default) returns a pending handle
+   *  immediately (legacy). >0 waits inline for the decision (#42). */
+  approvalWaitMs?: number;
+  /** Poll interval (ms) while waiting for an approval decision. */
+  approvalPollMs?: number;
 }
 
 export interface ApiErrorResponse {


### PR DESCRIPTION
Closes #42.

**What:** the AgentGate MCP server can **wait inline** for an approval decision instead of always returning a pending handle the agent must poll. The report's 'MCP-native inline approval' (beats Portkey's 'coming soon'). **Opt-in** via `AGENTGATE_APPROVAL_WAIT_MS` (>0); default `0` = legacy behavior, **byte-for-byte unchanged** (a `require_approval` returns the pending handle immediately, no polling — asserted by test).

**How:**
- `waitForApproval(config, requestId, {waitMs, pollMs})` — long-polls `GET /api/requests/:id` until the status leaves `pending` or the budget elapses; transient read errors are retried (not fatal).
- `executeGatedToolCall()` — authorize → optional inline wait → run/block. **approved** → run the tool; **denied/expired** → error result; **still pending at timeout** → the usual pending handle (a slow approver never blocks indefinitely).
- `index.ts` CallTool delegates to it; config reads `AGENTGATE_APPROVAL_WAIT_MS` / `_POLL_MS` (default 0 / 2000). docs/mcp.md updated.

**Tests:** 8 new cases (waitForApproval decided/timeout; approved-runs-tool, denied→isError, timeout→pending-handle, **waitMs=0 never polls**, deny→no-poll). Full build + 58 MCP tests green.

Default-off; the legacy pending-handle path is preserved + asserted.