### PR TITLE
feat(escalation): fallback decision on timeout — escalation chains (#44)

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -117,7 +117,7 @@ export interface RequestDecidedEvent
     action: string;
     status: Extract<ApprovalStatus, "approved" | "denied">;
     decidedBy: string;
-    decidedByType: "human" | "agent" | "policy" | "budget_limiter" | "eval_gate" | "override";
+    decidedByType: "human" | "agent" | "policy" | "budget_limiter" | "eval_gate" | "override" | "escalation_fallback";
     reason?: string;
     /** Time from creation to decision in milliseconds */
     decisionTimeMs: number;

--- a/packages/server/src/__tests__/escalation-fallback.test.ts
+++ b/packages/server/src/__tests__/escalation-fallback.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Escalation fallback decision (#44) — a `decision:*` escalation rule resolves a
+ * request that no human ever answers, instead of leaving it pending forever.
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import * as schema from "../db/schema.js";
+
+const { approvalRequests, escalationRules, escalationHistory } = schema;
+
+const sqlite = new Database(":memory:");
+const db = drizzle(sqlite, { schema });
+
+const MIGRATIONS_SQL = `
+CREATE TABLE IF NOT EXISTS approval_requests (id text PRIMARY KEY NOT NULL, action text NOT NULL, params text, context text, status text NOT NULL, urgency text NOT NULL, created_at integer NOT NULL, updated_at integer NOT NULL, decided_at integer, decided_by text, decision_reason text, expires_at integer, verified_agent_id text);
+CREATE TABLE IF NOT EXISTS escalation_rules (id text PRIMARY KEY NOT NULL, policy_id text, trigger_after_sec integer NOT NULL DEFAULT 1800, escalate_to text NOT NULL, priority integer NOT NULL DEFAULT 0, enabled integer NOT NULL DEFAULT 1, created_at integer NOT NULL);
+CREATE TABLE IF NOT EXISTS escalation_history (id text PRIMARY KEY NOT NULL, request_id text NOT NULL, rule_id text NOT NULL, escalated_at integer NOT NULL, from_channel text, to_channel text NOT NULL);
+`;
+for (const stmt of MIGRATIONS_SQL.split(";")) {
+  const t = stmt.trim();
+  if (t) sqlite.exec(t);
+}
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => db,
+  approvalRequests: schema.approvalRequests,
+  escalationRules: schema.escalationRules,
+  escalationHistory: schema.escalationHistory,
+}));
+vi.mock("../lib/webhook.js", () => ({ deliverWebhook: vi.fn() }));
+vi.mock("../lib/audit.js", () => ({ logAuditEvent: vi.fn() }));
+vi.mock("../lib/logger.js", () => ({
+  getLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import { scanPendingEscalations } from "../lib/escalation.js";
+
+afterAll(() => sqlite.close());
+
+async function seedPending(ageSec: number): Promise<string> {
+  const id = nanoid();
+  await db.insert(approvalRequests).values({
+    id, action: "deploy", status: "pending", urgency: "normal",
+    createdAt: new Date(Date.now() - ageSec * 1000), updatedAt: new Date(),
+  });
+  return id;
+}
+
+async function seedRule(escalateTo: string, triggerAfterSec = 60, priority = 0): Promise<void> {
+  await db.insert(escalationRules).values({
+    id: nanoid(), policyId: null, triggerAfterSec, escalateTo, priority, enabled: 1,
+    createdAt: Math.floor(Date.now() / 1000),
+  });
+}
+
+async function statusOf(id: string): Promise<{ status: string; decidedBy: string | null }> {
+  const [r] = await db.select().from(approvalRequests).where(eq(approvalRequests.id, id));
+  return { status: r.status, decidedBy: r.decidedBy };
+}
+
+describe("escalation fallback decision (#44)", () => {
+  beforeEach(() => {
+    sqlite.exec("DELETE FROM escalation_history");
+    sqlite.exec("DELETE FROM escalation_rules");
+    sqlite.exec("DELETE FROM approval_requests");
+  });
+
+  it("auto-denies a timed-out request via a decision:deny rule", async () => {
+    const reqId = await seedPending(7200); // 2h old
+    await seedRule("decision:deny", 60);
+    const n = await scanPendingEscalations();
+    expect(n).toBe(1);
+    const r = await statusOf(reqId);
+    expect(r.status).toBe("denied");
+    expect(r.decidedBy).toBe("escalation_fallback");
+    const hist = await db.select().from(escalationHistory).where(eq(escalationHistory.requestId, reqId));
+    expect(hist.length).toBe(1);
+  });
+
+  it("auto-approves via a decision:approve rule", async () => {
+    const reqId = await seedPending(7200);
+    await seedRule("decision:approve", 60);
+    await scanPendingEscalations();
+    expect((await statusOf(reqId)).status).toBe("approved");
+  });
+
+  it("leaves a request pending until its timeout elapses", async () => {
+    const reqId = await seedPending(10); // 10s old
+    await seedRule("decision:deny", 3600); // 1h threshold
+    await scanPendingEscalations();
+    expect((await statusOf(reqId)).status).toBe("pending");
+  });
+
+  it("a channel rule notifies but does NOT decide (no fallback)", async () => {
+    const reqId = await seedPending(7200);
+    await seedRule("slack:#escalation", 60);
+    await scanPendingEscalations();
+    expect((await statusOf(reqId)).status).toBe("pending");
+  });
+});

--- a/packages/server/src/lib/escalation.ts
+++ b/packages/server/src/lib/escalation.ts
@@ -10,7 +10,66 @@ import { nanoid } from "nanoid";
 import { getDb, approvalRequests, escalationRules, escalationHistory } from "../db/index.js";
 import { getLogger } from "./logger.js";
 import { deliverWebhook } from "./webhook.js";
-import { EventNames, createBaseEvent, type RequestEscalatedEvent } from "@agentgate/core";
+import { logAuditEvent } from "./audit.js";
+import {
+  EventNames,
+  createBaseEvent,
+  getGlobalEmitter,
+  type RequestEscalatedEvent,
+  type RequestDecidedEvent,
+} from "@agentgate/core";
+
+/** Parse an escalateTo of the form `decision:approve` / `decision:deny`. */
+function parseFallbackDecision(escalateTo: string): "approved" | "denied" | null {
+  if (escalateTo === "decision:approve") return "approved";
+  if (escalateTo === "decision:deny") return "denied";
+  return null;
+}
+
+/**
+ * Terminal fallback (#44): when an escalation rule's target is a `decision:*`,
+ * auto-resolve a still-pending request instead of notifying — so a request that
+ * no human ever answers doesn't sit pending forever. Mirrors the auto-decision
+ * side effects (audit + event + webhook) so downstream sees a normal decision.
+ */
+async function applyFallbackDecision(
+  request: typeof approvalRequests.$inferSelect,
+  status: "approved" | "denied",
+  triggerAfterSec: number,
+): Promise<void> {
+  const db = getDb();
+  const reason = `No decision after ${triggerAfterSec}s — escalation fallback ${status}`;
+  await db
+    .update(approvalRequests)
+    .set({ status, decidedAt: new Date(), decidedBy: "escalation_fallback", decisionReason: reason })
+    .where(eq(approvalRequests.id, request.id));
+
+  await logAuditEvent(request.id, status, "escalation_fallback", {
+    reason,
+    automatic: true,
+    decidedByType: "escalation_fallback",
+  });
+
+  const decidedEvent: RequestDecidedEvent = {
+    ...createBaseEvent(EventNames.REQUEST_DECIDED, "escalation-scanner"),
+    payload: {
+      requestId: request.id,
+      action: request.action,
+      status,
+      decidedBy: "escalation_fallback",
+      decidedByType: "escalation_fallback",
+      reason,
+      decisionTimeMs: 0,
+    },
+  };
+  getGlobalEmitter().emitSync(decidedEvent);
+
+  try {
+    await deliverWebhook(`request.${status}`, { request });
+  } catch {
+    // best-effort: the decision already persisted
+  }
+}
 
 let scannerTimer: NodeJS.Timeout | null = null;
 
@@ -107,6 +166,19 @@ export async function scanPendingEscalations(): Promise<number> {
 
       // Mark as escalated so we don't process again in this pass
       alreadyEscalated.add(key);
+
+      // Terminal fallback rule (#44): resolve the request instead of notifying,
+      // then stop — it's no longer pending, so later rungs don't apply.
+      const fallback = parseFallbackDecision(rule.escalateTo);
+      if (fallback) {
+        await applyFallbackDecision(request, fallback, rule.triggerAfterSec);
+        log.info(
+          { requestId: request.id, ruleId: rule.id, decision: fallback },
+          "Escalation fallback decision applied"
+        );
+        escalationCount++;
+        break; // request resolved — skip remaining rules for it
+      }
 
       // Dispatch notification via webhook
       const escalationEvent: RequestEscalatedEvent = {

--- a/packages/server/src/routes/audit.ts
+++ b/packages/server/src/routes/audit.ts
@@ -77,7 +77,7 @@ auditRouter.get("/", async (c) => {
 
   // decidedByType (#22): lives in the decision audit event's details JSON
   // (set by the auto-decision / human-decide path). Match it backend-agnostically.
-  const validDecidedByTypes = ["policy", "human", "agent", "budget_limiter", "eval_gate", "override"];
+  const validDecidedByTypes = ["policy", "human", "agent", "budget_limiter", "eval_gate", "override", "escalation_fallback"];
   if (decidedByType && validDecidedByTypes.includes(decidedByType)) {
     auditConditions.push(
       getDialect() === "postgres"

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -140,7 +140,7 @@ async function handleAutoDecision(opts: {
   action: string;
   status: "approved" | "denied";
   decidedBy: string;
-  decidedByType: "policy" | "human" | "agent" | "budget_limiter" | "eval_gate" | "override";
+  decidedByType: "policy" | "human" | "agent" | "budget_limiter" | "eval_gate" | "override" | "escalation_fallback";
   decisionReason: string | null;
   requestSnapshot: Record<string, unknown>;
   channels?: string[];


### PR DESCRIPTION
Closes #44.

**What:** agentgate already escalates a pending request to channels by time + priority (`escalation_rules` form a chain). This adds the missing **terminal rung**: a rule whose `escalateTo` is `decision:approve` or `decision:deny` **auto-resolves** a request no human ever answers, instead of leaving it pending forever (HumanLayer parity).

**How:**
- `escalation.ts` — `scanPendingEscalations` branches on a `decision:*` target → `applyFallbackDecision` (update status/decidedBy/decidedAt/reason + audit + `RequestDecided` event + webhook, mirroring the auto-decision side effects), then stops processing further rungs for that request. **Channel rules unchanged.** Configure the fallback as the lowest-priority / longest-timeout rung of a chain.
- `core/events.ts` + `routes/{audit,requests}.ts` — add `escalation_fallback` to the `decidedByType` union / audit filter list (queryable + consistent downstream).

**Default-safe:** fires **only** when an admin creates a `decision:*` rule; no existing rule or default behavior changes.

**Tests:** `escalation-fallback.test.ts` (auto-deny on timeout + history, auto-approve, not-yet-due stays pending, channel rule notifies-not-decides). 4/4 + 8 existing audit/decide tests green; full build + eslint clean.