### PR TITLE
ci(docker): publish to ghcr.io/agentkitai/agentgate (#96)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,7 @@
-name: Docker Hub
+name: Docker (GHCR)
+
+# Publishes the public image to ghcr.io/agentkitai/agentgate using the built-in
+# GITHUB_TOKEN — no Docker Hub credentials needed (#96 org-registry migration).
 
 on:
   push:
@@ -13,6 +16,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -21,17 +27,18 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: pazgaz/agentgate
+          images: ghcr.io/agentkitai/agentgate
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Part of #96 (org-registry migration). Retargets the image from Docker Hub (`pazgaz/agentgate`) to **`ghcr.io/agentkitai/agentgate`** via the built-in `GITHUB_TOKEN` (`packages: write`, no Docker Hub secrets). **Unblocks agentkit-stack #3/#4/#5/#7.**

Owner one-time: after the first `v*` tag pushes the image, flip the GHCR package → Public + connect to repo (defaults to private).