### PR TITLE
chore(scope): migrate agentgate packages to @agentkitai/* (#96)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,11 +8,11 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@agentgate/server",
-    "@agentgate/dashboard",
-    "@agentgate/demo",
-    "@agentgate/mcp",
-    "@agentgate/slack",
-    "@agentgate/github-action"
+    "@agentkitai/agentgate-server",
+    "@agentkitai/agentgate-dashboard",
+    "@agentkitai/agentgate-demo",
+    "@agentkitai/agentgate-mcp",
+    "@agentkitai/agentgate-slack",
+    "@agentkitai/agentgate-github-action"
   ]
 }

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,12 +1,12 @@
-name: Publish @agentgate/mcp + MCP Registry
+name: Publish @agentkitai/agentgate-mcp + MCP Registry
 
-# An `mcp-v*` tag publishes @agentgate/mcp to npm via OIDC Trusted Publishing
+# An `mcp-v*` tag publishes @agentkitai/agentgate-mcp to npm via OIDC Trusted Publishing
 # (no token) and lists/updates the server in the official MCP Registry via
 # GitHub Actions OIDC (no token). Kept separate from the changesets release.yml
 # so the two never entangle.
 #
 # One-time setup (owner, in a browser — no secrets ever stored):
-#   * npm Trusted Publisher for package `@agentgate/mcp`: repo
+#   * npm Trusted Publisher for package `@agentkitai/agentgate-mcp`: repo
 #     agentkitai/agentgate, workflow `publish-mcp.yml`.
 #   * MCP Registry namespace `io.github.agentkitai/*` is proven automatically by
 #     this repo's GitHub OIDC token — nothing to configure.
@@ -39,19 +39,19 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build the MCP package (and its workspace dep @agentgate/core)
+      - name: Build the MCP package (and its workspace dep @agentkitai/agentgate-core)
         run: |
-          pnpm --filter @agentgate/core build
-          pnpm --filter @agentgate/mcp build
+          pnpm --filter @agentkitai/agentgate-core build
+          pnpm --filter @agentkitai/agentgate-mcp build
 
-      - name: Publish @agentgate/mcp to npm (OIDC Trusted Publishing)
+      - name: Publish @agentkitai/agentgate-mcp to npm (OIDC Trusted Publishing)
         run: |
           set -euo pipefail
           V=$(node -p "require('./packages/mcp/package.json').version")
-          if npm view "@agentgate/mcp@$V" version >/dev/null 2>&1; then
-            echo "@agentgate/mcp@$V already on npm — skipping publish (idempotent re-run)"
+          if npm view "@agentkitai/agentgate-mcp@$V" version >/dev/null 2>&1; then
+            echo "@agentkitai/agentgate-mcp@$V already on npm — skipping publish (idempotent re-run)"
           else
-            pnpm --filter @agentgate/mcp publish --access public --no-git-checks
+            pnpm --filter @agentkitai/agentgate-mcp publish --access public --no-git-checks
           fi
 
       - name: Publish to the MCP Registry (GitHub Actions OIDC)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -6,9 +6,9 @@ This monorepo uses [Changesets](https://github.com/changesets/changesets) for ve
 
 The following packages are published to npm:
 
-- `@agentgate/core` - Core types and utilities
-- `@agentgate/sdk` - SDK for integrating AgentGate
-- `@agentgate/cli` - CLI for approval management
+- `@agentkitai/agentgate-core` - Core types and utilities
+- `@agentkitai/agentgate-sdk` - SDK for integrating AgentGate
+- `@agentkitai/agentgate-cli` - CLI for approval management
 
 ## Adding a Changeset
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/search?q=%40agentgate"><img src="https://img.shields.io/npm/v/@agentgate/sdk?label=sdk&color=blue" alt="npm version"></a>
+  <a href="https://www.npmjs.com/search?q=%40agentgate"><img src="https://img.shields.io/npm/v/@agentkitai/agentgate-sdk?label=sdk&color=blue" alt="npm version"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
   <a href="https://github.com/agentkitai/agentgate/actions"><img src="https://img.shields.io/github/actions/workflow/status/agentkitai/agentgate/ci.yml?branch=main" alt="CI"></a>
   <a href="#"><img src="https://img.shields.io/badge/TypeScript-5.x-blue?logo=typescript&logoColor=white" alt="TypeScript"></a>
@@ -51,7 +51,7 @@ pnpm install && pnpm migrate && pnpm bootstrap && pnpm dev
 Drop AgentGate into an MCP client (Claude Desktop / Cursor / VS Code) — point it at the gateway:
 
 ```jsonc
-{ "mcpServers": { "agentgate": { "command": "npx", "args": ["@agentgate/mcp"] } } }
+{ "mcpServers": { "agentgate": { "command": "npx", "args": ["@agentkitai/agentgate-mcp"] } } }
 ```
 
 #### Dashboard
@@ -123,13 +123,13 @@ pnpm install
 ### 2. Run database migrations
 
 ```bash
-pnpm --filter @agentgate/server db:migrate
+pnpm --filter @agentkitai/agentgate-server db:migrate
 ```
 
 ### 3. Bootstrap (create admin API key)
 
 ```bash
-pnpm --filter @agentgate/server bootstrap
+pnpm --filter @agentkitai/agentgate-server bootstrap
 ```
 
 **Save the API key** - it's shown once only! Set it in your environment:
@@ -163,7 +163,7 @@ Visit **http://localhost:5173** to view and manage approval requests.
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                         AI Agents                                │
-│  (use @agentgate/sdk or MCP to request approvals)               │
+│  (use @agentkitai/agentgate-sdk or MCP to request approvals)               │
 └───────────────────────────┬─────────────────────────────────────┘
                             │ HTTP API (authenticated)
                             ▼
@@ -194,19 +194,19 @@ Visit **http://localhost:5173** to view and manage approval requests.
 
 | Package | Description | Docs |
 |---------|-------------|------|
-| [`@agentgate/core`](./packages/core) | Types, schemas, policy engine | - |
-| [`@agentgate/server`](./packages/server) | Hono API server | - |
-| [`@agentgate/sdk`](./packages/sdk) | TypeScript SDK for agents | [README](./packages/sdk/README.md) |
-| [`@agentgate/cli`](./packages/cli) | Command-line interface | - |
-| [`@agentgate/mcp`](./packages/mcp) | MCP server for Claude Desktop | - |
-| [`@agentgate/slack`](./packages/slack) | Slack bot integration | [README](./packages/slack/README.md) |
-| [`@agentgate/discord`](./packages/discord) | Discord bot integration | [README](./packages/discord/README.md) |
-| [`@agentgate/dashboard`](./packages/dashboard) | React web dashboard | - |
+| [`@agentkitai/agentgate-core`](./packages/core) | Types, schemas, policy engine | - |
+| [`@agentkitai/agentgate-server`](./packages/server) | Hono API server | - |
+| [`@agentkitai/agentgate-sdk`](./packages/sdk) | TypeScript SDK for agents | [README](./packages/sdk/README.md) |
+| [`@agentkitai/agentgate-cli`](./packages/cli) | Command-line interface | - |
+| [`@agentkitai/agentgate-mcp`](./packages/mcp) | MCP server for Claude Desktop | - |
+| [`@agentkitai/agentgate-slack`](./packages/slack) | Slack bot integration | [README](./packages/slack/README.md) |
+| [`@agentkitai/agentgate-discord`](./packages/discord) | Discord bot integration | [README](./packages/discord/README.md) |
+| [`@agentkitai/agentgate-dashboard`](./packages/dashboard) | React web dashboard | - |
 
 ## SDK Usage
 
 ```typescript
-import { AgentGateClient } from '@agentgate/sdk';
+import { AgentGateClient } from '@agentkitai/agentgate-sdk';
 
 // Create client with API key
 const client = new AgentGateClient({
@@ -245,10 +245,10 @@ AgentGate includes a command-line interface for managing approval requests.
 
 ```bash
 # From the monorepo
-pnpm --filter @agentgate/cli build
+pnpm --filter @agentkitai/agentgate-cli build
 
 # Or install globally (when published)
-npm install -g @agentgate/cli
+npm install -g @agentkitai/agentgate-cli
 ```
 
 ### Configuration
@@ -319,7 +319,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "agentgate": {
       "command": "npx",
-      "args": ["@agentgate/mcp"],
+      "args": ["@agentkitai/agentgate-mcp"],
       "env": {
         "AGENTGATE_URL": "http://localhost:3000",
         "AGENTGATE_API_KEY": "agk_..."
@@ -708,10 +708,10 @@ docker-compose down -v
 pnpm install
 
 # Run migrations
-pnpm --filter @agentgate/server db:migrate
+pnpm --filter @agentkitai/agentgate-server db:migrate
 
 # Bootstrap (create admin key)
-pnpm --filter @agentgate/server bootstrap
+pnpm --filter @agentkitai/agentgate-server bootstrap
 
 # Start development (server + dashboard)
 pnpm dev
@@ -729,10 +729,10 @@ pnpm test
 pnpm test:coverage
 
 # Run tests in watch mode (single package)
-pnpm --filter @agentgate/server test:watch
+pnpm --filter @agentkitai/agentgate-server test:watch
 
 # Run a specific test file
-pnpm --filter @agentgate/server test -- src/__tests__/integration.test.ts
+pnpm --filter @agentkitai/agentgate-server test -- src/__tests__/integration.test.ts
 ```
 
 Coverage reports are generated per-package and include line, branch, and function coverage.

--- a/action/package.json
+++ b/action/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/github-action",
+  "name": "@agentkitai/agentgate-github-action",
   "version": "0.0.1",
   "private": true,
   "description": "GitHub Action for AgentGate approval requests",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/demo",
+  "name": "@agentkitai/agentgate-demo",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@agentgate/sdk": "workspace:*"
+    "@agentkitai/agentgate-sdk": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.2"

--- a/apps/demo/src/index.ts
+++ b/apps/demo/src/index.ts
@@ -17,7 +17,7 @@
  *   - pnpm dev (from root) starts server + dashboard
  */
 
-import { AgentGateClient, TimeoutError } from "@agentgate/sdk";
+import { AgentGateClient, TimeoutError } from "@agentkitai/agentgate-sdk";
 
 // Configuration
 const SERVER_URL = process.env.AGENTGATE_URL || "http://localhost:3000";

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,18 +1,18 @@
 # Command-Line Interface
 
-The `@agentgate/cli` package provides a command-line interface for managing approval requests.
+The `@agentkitai/agentgate-cli` package provides a command-line interface for managing approval requests.
 
 ## Installation
 
 ```bash
 # Global install
-npm install -g @agentgate/cli
+npm install -g @agentkitai/agentgate-cli
 
 # Or run with npx
-npx @agentgate/cli --help
+npx @agentkitai/agentgate-cli --help
 
 # Or from the monorepo
-pnpm --filter @agentgate/cli build
+pnpm --filter @agentkitai/agentgate-cli build
 ```
 
 ## Configuration

--- a/docs/events.md
+++ b/docs/events.md
@@ -4,10 +4,10 @@ AgentGate includes a built-in event system for observing system activity and a n
 
 ## AgentGateEmitter and Event Types
 
-All significant actions in AgentGate emit typed events. Event names are defined as constants in `@agentgate/core`:
+All significant actions in AgentGate emit typed events. Event names are defined as constants in `@agentkitai/agentgate-core`:
 
 ```typescript
-import { EventNames } from "@agentgate/core";
+import { EventNames } from "@agentkitai/agentgate-core";
 ```
 
 ### Event Name Constants
@@ -59,7 +59,7 @@ interface BaseEvent<T extends EventName> {
 Use the `createBaseEvent` helper to generate events with pre-filled common fields:
 
 ```typescript
-import { createBaseEvent } from "@agentgate/core";
+import { createBaseEvent } from "@agentkitai/agentgate-core";
 
 const base = createBaseEvent("request.created", "my-plugin");
 // → { type: "request.created", timestamp: …, eventId: "evt_…", source: "my-plugin" }
@@ -72,7 +72,7 @@ const base = createBaseEvent("request.created", "my-plugin");
 Use the `AgentGateEmitter` class to subscribe to events. The global singleton is available via `getGlobalEmitter()`, or create an isolated instance with `createEmitter()`.
 
 ```typescript
-import { getGlobalEmitter, createEmitter } from "@agentgate/core";
+import { getGlobalEmitter, createEmitter } from "@agentkitai/agentgate-core";
 
 const emitter = getGlobalEmitter();
 ```
@@ -119,7 +119,7 @@ Explicitly unsubscribe a listener (alternative to calling the function returned 
 Emit an event. `emit` is async and awaits all listeners; `emitSync` is fire-and-forget.
 
 ```typescript
-import { createBaseEvent, EventNames } from "@agentgate/core";
+import { createBaseEvent, EventNames } from "@agentkitai/agentgate-core";
 
 const event = {
   ...createBaseEvent(EventNames.SYSTEM_ERROR, "my-plugin"),
@@ -247,7 +247,7 @@ Each event type carries a typed `payload`. All fields are listed below.
 The `eventMatchesFilter` function checks whether an event matches a filter:
 
 ```typescript
-import { eventMatchesFilter } from "@agentgate/core";
+import { eventMatchesFilter } from "@agentkitai/agentgate-core";
 
 const match = eventMatchesFilter(event, {
   types: ["request.created", "request.decided"],  // Match these event types
@@ -284,7 +284,7 @@ Results are deduplicated by `channel:target` to avoid duplicate notifications.
 ### Usage
 
 ```typescript
-import { createDispatcher, getGlobalDispatcher } from "@agentgate/server";
+import { createDispatcher, getGlobalDispatcher } from "@agentkitai/agentgate-server";
 
 // Use the singleton
 const dispatcher = getGlobalDispatcher();
@@ -376,12 +376,12 @@ Here's a complete example of building an SMS adapter using Twilio:
 
 ```typescript
 // adapters/sms.ts
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import type {
   NotificationChannelAdapter,
   NotificationChannelType,
   NotificationResult,
-} from "@agentgate/server/lib/notification/types";
+} from "@agentkitai/agentgate-server/lib/notification/types";
 
 export class SmsAdapter implements NotificationChannelAdapter {
   // The type must be a valid NotificationChannelType.
@@ -503,7 +503,7 @@ export class SmsAdapter implements NotificationChannelAdapter {
 Register your adapter with the dispatcher:
 
 ```typescript
-import { getGlobalDispatcher, createDispatcher } from "@agentgate/server";
+import { getGlobalDispatcher, createDispatcher } from "@agentkitai/agentgate-server";
 import { SmsAdapter } from "./adapters/sms";
 
 // Option 1: Register on the global singleton

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,10 +41,10 @@ cd agentgate
 pnpm install
 
 # Run database migrations
-pnpm --filter @agentgate/server db:migrate
+pnpm --filter @agentkitai/agentgate-server db:migrate
 
 # Bootstrap (create admin API key)
-pnpm --filter @agentgate/server bootstrap
+pnpm --filter @agentkitai/agentgate-server bootstrap
 ```
 
 ::: tip Save Your API Key
@@ -74,7 +74,7 @@ Access the services:
 
 ```bash
 # Install and configure CLI
-pnpm --filter @agentgate/cli build
+pnpm --filter @agentkitai/agentgate-cli build
 export AGENTGATE_URL=http://localhost:3000
 export AGENTGATE_API_KEY=agk_...
 
@@ -90,7 +90,7 @@ agentgate list --status pending
 ### Using the SDK
 
 ```typescript
-import { AgentGateClient } from '@agentgate/sdk'
+import { AgentGateClient } from '@agentkitai/agentgate-sdk'
 
 const client = new AgentGateClient({
   baseUrl: 'http://localhost:3000',
@@ -131,7 +131,7 @@ The demo creates sample approval requests that you can approve or deny in the da
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                         AI Agents                                │
-│  (use @agentgate/sdk or MCP to request approvals)               │
+│  (use @agentkitai/agentgate-sdk or MCP to request approvals)               │
 └───────────────────────────┬─────────────────────────────────────┘
                             │ HTTP API (authenticated)
                             ▼

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ features:
 ## Quick Example
 
 ```typescript
-import { AgentGateClient } from '@agentgate/sdk'
+import { AgentGateClient } from '@agentkitai/agentgate-sdk'
 
 const client = new AgentGateClient({
   baseUrl: 'http://localhost:3000',

--- a/docs/integrations/discord.md
+++ b/docs/integrations/discord.md
@@ -71,7 +71,7 @@ docker-compose --profile bots up -d
 DISCORD_BOT_TOKEN=... \
 DISCORD_DEFAULT_CHANNEL=... \
 AGENTGATE_URL=http://localhost:3000 \
-npx @agentgate/discord
+npx @agentkitai/agentgate-discord
 ```
 
 ## Message Format

--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -1,6 +1,6 @@
 # Slack Integration
 
-The `@agentgate/slack` package provides a Slack bot for sending approval requests and receiving decisions directly in Slack.
+The `@agentkitai/agentgate-slack` package provides a Slack bot for sending approval requests and receiving decisions directly in Slack.
 
 ## Features
 
@@ -76,19 +76,19 @@ docker-compose --profile bots up -d
 
 ```bash
 # Install
-npm install @agentgate/slack
+npm install @agentkitai/agentgate-slack
 
 # Run
 SLACK_BOT_TOKEN=xoxb-... \
 SLACK_SIGNING_SECRET=... \
 AGENTGATE_URL=http://localhost:3000 \
-npx @agentgate/slack
+npx @agentkitai/agentgate-slack
 ```
 
 ### As a Library
 
 ```typescript
-import { createSlackBot } from '@agentgate/slack'
+import { createSlackBot } from '@agentkitai/agentgate-slack'
 
 const bot = createSlackBot({
   token: process.env.SLACK_BOT_TOKEN!,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -17,7 +17,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "agentgate": {
       "command": "npx",
-      "args": ["@agentgate/mcp"],
+      "args": ["@agentkitai/agentgate-mcp"],
       "env": {
         "AGENTGATE_URL": "http://localhost:3000",
         "AGENTGATE_API_KEY": "agk_your_api_key"
@@ -33,7 +33,7 @@ Add to your `claude_desktop_config.json`:
   "mcpServers": {
     "agentgate": {
       "command": "npx",
-      "args": ["@agentgate/mcp"],
+      "args": ["@agentkitai/agentgate-mcp"],
       "env": {
         "AGENTGATE_URL": "http://localhost:3000",
         "AGENTGATE_API_KEY": "agk_your_api_key"
@@ -256,7 +256,7 @@ For testing or development:
 
 ```bash
 # Install globally
-npm install -g @agentgate/mcp
+npm install -g @agentkitai/agentgate-mcp
 
 # Run directly
 AGENTGATE_URL=http://localhost:3000 \
@@ -268,7 +268,7 @@ agentgate-mcp
 
 ```bash
 # From the monorepo
-pnpm --filter @agentgate/mcp build
+pnpm --filter @agentkitai/agentgate-mcp build
 
 # Test locally
 node packages/mcp/dist/index.js
@@ -276,4 +276,4 @@ node packages/mcp/dist/index.js
 
 ## Other MCP Clients
 
-The MCP server works with any MCP-compatible client, not just Claude Desktop. Configure it as a stdio-based MCP server pointing to `@agentgate/mcp`.
+The MCP server works with any MCP-compatible client, not just Claude Desktop. Configure it as a stdio-based MCP server pointing to `@agentkitai/agentgate-mcp`.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,21 +1,21 @@
 # TypeScript SDK
 
-The `@agentgate/sdk` package provides a type-safe client for AI agents to request human approvals.
+The `@agentkitai/agentgate-sdk` package provides a type-safe client for AI agents to request human approvals.
 
 ## Installation
 
 ```bash
-npm install @agentgate/sdk
+npm install @agentkitai/agentgate-sdk
 # or
-pnpm add @agentgate/sdk
+pnpm add @agentkitai/agentgate-sdk
 # or
-yarn add @agentgate/sdk
+yarn add @agentkitai/agentgate-sdk
 ```
 
 ## Quick Start
 
 ```typescript
-import { AgentGateClient } from '@agentgate/sdk'
+import { AgentGateClient } from '@agentkitai/agentgate-sdk'
 
 const client = new AgentGateClient({
   baseUrl: 'http://localhost:3000',
@@ -115,7 +115,7 @@ const requests = await client.listRequests({
 ## Error Handling
 
 ```typescript
-import { AgentGateError, TimeoutError } from '@agentgate/sdk'
+import { AgentGateError, TimeoutError } from '@agentkitai/agentgate-sdk'
 
 try {
   await client.waitForDecision(id)
@@ -130,7 +130,7 @@ try {
 
 ## Types
 
-All types from `@agentgate/core` are re-exported:
+All types from `@agentkitai/agentgate-core` are re-exported:
 
 ```typescript
 import type {
@@ -141,7 +141,7 @@ import type {
   Policy,
   PolicyRule,
   PolicyDecision
-} from '@agentgate/sdk'
+} from '@agentkitai/agentgate-sdk'
 ```
 
 ## Usage Patterns

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -230,7 +230,7 @@ This guide covers common issues when running AgentGate, organized by **Symptom â
 **Solution:**
 1. **SQLite (default):** Run migrations manually:
    ```bash
-   pnpm --filter @agentgate/server db:migrate
+   pnpm --filter @agentkitai/agentgate-server db:migrate
    ```
 2. **PostgreSQL:** Ensure the database exists and is reachable:
    ```bash
@@ -313,7 +313,7 @@ curl http://localhost:3000/health
 ### View structured logs
 Set `LOG_LEVEL=debug` and `LOG_FORMAT=json` for detailed, parseable logs:
 ```bash
-LOG_LEVEL=debug LOG_FORMAT=json pnpm --filter @agentgate/server dev
+LOG_LEVEL=debug LOG_FORMAT=json pnpm --filter @agentkitai/agentgate-server dev
 ```
 
 ### Validate configuration

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentgate",
+  "name": "@agentkitai/agentgate-monorepo",
   "repository": {
     "type": "git",
     "url": "https://github.com/agentkitai/agentgate.git"
@@ -13,8 +13,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "pnpm -r run typecheck",
-    "dev": "pnpm --filter @agentgate/server --filter @agentgate/dashboard -r --parallel run dev",
-    "demo": "pnpm --filter @agentgate/demo run start",
+    "dev": "pnpm --filter @agentkitai/agentgate-server --filter @agentkitai/agentgate-dashboard -r --parallel run dev",
+    "demo": "pnpm --filter @agentkitai/agentgate-demo run start",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "docs:dev": "vitepress dev docs",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @agentgate/cli
+# @agentkitai/agentgate-cli
 
 ## 0.1.0
 
@@ -18,7 +18,7 @@
 ### Patch Changes
 
 - Updated dependencies [e74f7b7]
-  - @agentgate/core@0.1.0
+  - @agentkitai/agentgate-core@0.1.0
 
 ## 0.0.2
 
@@ -34,4 +34,4 @@
   - AgentGateEmitter API documented in events.md
 
 - Updated dependencies [618e2da]
-  - @agentgate/core@0.0.2
+  - @agentkitai/agentgate-core@0.0.2

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,11 +1,11 @@
-# @agentgate/cli
+# @agentkitai/agentgate-cli
 
 Command-line interface for AgentGate approval management.
 
 ## Installation
 
 ```bash
-pnpm add -g @agentgate/cli
+pnpm add -g @agentkitai/agentgate-cli
 ```
 
 ## Usage
@@ -101,7 +101,7 @@ Configuration is stored in `~/.agentgate/config.json`:
 The CLI can also be used programmatically:
 
 ```typescript
-import { ApiClient, loadConfig } from '@agentgate/cli';
+import { ApiClient, loadConfig } from '@agentkitai/agentgate-cli';
 
 const client = new ApiClient();
 const requests = await client.listRequests({ status: 'pending' });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/cli",
+  "name": "@agentkitai/agentgate-cli",
   "version": "0.1.0",
   "description": "CLI for AgentGate approval management",
   "type": "module",
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@agentgate/core": "workspace:*",
+    "@agentkitai/agentgate-core": "workspace:*",
     "commander": "^12.1.0"
   },
   "devDependencies": {

--- a/packages/cli/src/api.test.ts
+++ b/packages/cli/src/api.test.ts
@@ -1,8 +1,8 @@
-// @agentgate/cli - API client tests
+// @agentkitai/agentgate-cli - API client tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ApiClient, formatRequest, formatRequestList } from './api.js';
-import type { ApprovalRequest } from '@agentgate/core';
+import type { ApprovalRequest } from '@agentkitai/agentgate-core';
 
 // Mock fetch
 const mockFetch = vi.fn();

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,6 +1,6 @@
-// @agentgate/cli - API client
+// @agentkitai/agentgate-cli - API client
 
-import type { ApprovalRequest, ApprovalStatus, OverrideAction } from '@agentgate/core';
+import type { ApprovalRequest, ApprovalStatus, OverrideAction } from '@agentkitai/agentgate-core';
 
 export type { OverrideAction };
 import { getResolvedConfig } from './config.js';

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - CLI tests
+// @agentkitai/agentgate-cli - CLI tests
 
 import { describe, it, expect } from 'vitest';
 import { VERSION } from './version.js';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// @agentgate/cli - CLI entry point
+// @agentkitai/agentgate-cli - CLI entry point
 
 import { Command } from 'commander';
 import {

--- a/packages/cli/src/commands/approve.test.ts
+++ b/packages/cli/src/commands/approve.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Approve command tests
+// @agentkitai/agentgate-cli - Approve command tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createApproveCommand } from './approve.js';

--- a/packages/cli/src/commands/approve.ts
+++ b/packages/cli/src/commands/approve.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Approve command
+// @agentkitai/agentgate-cli - Approve command
 
 import { Command } from 'commander';
 import { ApiClient, formatRequest } from '../api.js';

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Config command tests
+// @agentkitai/agentgate-cli - Config command tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createConfigCommand } from './config.js';

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Config command
+// @agentkitai/agentgate-cli - Config command
 
 import { Command } from 'commander';
 import { loadConfig, saveConfig, getConfigPath, setConfigValue } from '../config.js';

--- a/packages/cli/src/commands/deny.test.ts
+++ b/packages/cli/src/commands/deny.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Deny command tests
+// @agentkitai/agentgate-cli - Deny command tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createDenyCommand } from './deny.js';

--- a/packages/cli/src/commands/deny.ts
+++ b/packages/cli/src/commands/deny.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Deny command
+// @agentkitai/agentgate-cli - Deny command
 
 import { Command } from 'commander';
 import { ApiClient, formatRequest } from '../api.js';

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Command exports
+// @agentkitai/agentgate-cli - Command exports
 
 export { createConfigCommand } from './config.js';
 export { createRequestCommand } from './request.js';

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - List command tests
+// @agentkitai/agentgate-cli - List command tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createListCommand } from './list.js';

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - List command
+// @agentkitai/agentgate-cli - List command
 
 import { Command } from 'commander';
 import { ApiClient, formatRequestList } from '../api.js';

--- a/packages/cli/src/commands/override.test.ts
+++ b/packages/cli/src/commands/override.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Override command tests (#14)
+// @agentkitai/agentgate-cli - Override command tests (#14)
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createOverrideCommand } from './override.js';

--- a/packages/cli/src/commands/override.ts
+++ b/packages/cli/src/commands/override.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Override command (per-agent dynamic guardrails, #14)
+// @agentkitai/agentgate-cli - Override command (per-agent dynamic guardrails, #14)
 
 import { Command } from 'commander';
 import { ApiClient, formatOverrideList, type OverrideAction } from '../api.js';

--- a/packages/cli/src/commands/request.test.ts
+++ b/packages/cli/src/commands/request.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Request command tests
+// @agentkitai/agentgate-cli - Request command tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createRequestCommand } from './request.js';

--- a/packages/cli/src/commands/request.ts
+++ b/packages/cli/src/commands/request.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Request command
+// @agentkitai/agentgate-cli - Request command
 
 import { Command } from 'commander';
 import { ApiClient, formatRequest } from '../api.js';

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Status command tests
+// @agentkitai/agentgate-cli - Status command tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createStatusCommand } from './status.js';

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Status command
+// @agentkitai/agentgate-cli - Status command
 
 import { Command } from 'commander';
 import { ApiClient, formatRequest } from '../api.js';

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Config tests
+// @agentkitai/agentgate-cli - Config tests
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Configuration management
+// @agentkitai/agentgate-cli - Configuration management
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Public API
+// @agentkitai/agentgate-cli - Public API
 
 export { VERSION } from './version.js';
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,4 @@
-// @agentgate/cli - Types
+// @agentkitai/agentgate-cli - Types
 
 /**
  * CLI configuration stored in ~/.agentgate/config.json

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,3 +1,3 @@
-// @agentgate/cli - Version
+// @agentkitai/agentgate-cli - Version
 
 export const VERSION = '0.0.1';

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @agentgate/core
+# @agentkitai/agentgate-core
 
 ## 0.1.0
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/core",
+  "name": "@agentkitai/agentgate-core",
   "version": "0.1.0",
   "description": "Core types and utilities for AgentGate",
   "type": "module",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-// @agentgate/core - Core types and policy engine
+// @agentkitai/agentgate-core - Core types and policy engine
 
 export const VERSION = '0.0.1';
 

--- a/packages/core/src/policy-engine.ts
+++ b/packages/core/src/policy-engine.ts
@@ -1,4 +1,4 @@
-// @agentgate/core - Policy evaluation engine
+// @agentkitai/agentgate-core - Policy evaluation engine
 
 import isSafeRegex from 'safe-regex2';
 import type { ApprovalRequest, Policy, PolicyRule, PolicyDecision, MatcherValue } from './types.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-// @agentgate/core - Core types
+// @agentkitai/agentgate-core - Core types
 
 /**
  * Status of an approval request

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,4 +1,4 @@
-// @agentgate/core - Shared utility functions
+// @agentkitai/agentgate-core - Shared utility functions
 
 /**
  * Truncate a string to a max length, adding ellipsis if truncated

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/dashboard",
+  "name": "@agentkitai/agentgate-dashboard",
   "version": "0.0.1",
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
     "lint": "eslint src --ext .ts,.tsx"
   },
   "dependencies": {
-    "@agentgate/core": "workspace:*",
+    "@agentkitai/agentgate-core": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.0"

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -1,6 +1,6 @@
 // API client for AgentGate server
 
-import type { ApprovalStatus, ApprovalUrgency } from '@agentgate/core';
+import type { ApprovalStatus, ApprovalUrgency } from '@agentkitai/agentgate-core';
 
 export type { ApprovalStatus, ApprovalUrgency };
 

--- a/packages/dashboard/src/components/StatusBadge.tsx
+++ b/packages/dashboard/src/components/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import type { ApprovalStatus } from '@agentgate/core';
+import type { ApprovalStatus } from '@agentkitai/agentgate-core';
 
 interface StatusBadgeProps {
   status: ApprovalStatus;

--- a/packages/discord/CHANGELOG.md
+++ b/packages/discord/CHANGELOG.md
@@ -1,15 +1,15 @@
-# @agentgate/discord
+# @agentkitai/agentgate-discord
 
 ## 0.0.3
 
 ### Patch Changes
 
 - Updated dependencies [e74f7b7]
-  - @agentgate/core@0.1.0
+  - @agentkitai/agentgate-core@0.1.0
 
 ## 0.0.2
 
 ### Patch Changes
 
 - Updated dependencies [618e2da]
-  - @agentgate/core@0.0.2
+  - @agentkitai/agentgate-core@0.0.2

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -1,4 +1,4 @@
-# @agentgate/discord
+# @agentkitai/agentgate-discord
 
 Discord bot integration for AgentGate - receive approval requests and make decisions directly from Discord.
 
@@ -13,9 +13,9 @@ Discord bot integration for AgentGate - receive approval requests and make decis
 ## Installation
 
 ```bash
-pnpm add @agentgate/discord
+pnpm add @agentkitai/agentgate-discord
 # or
-npm install @agentgate/discord
+npm install @agentkitai/agentgate-discord
 ```
 
 ## Configuration
@@ -46,7 +46,7 @@ pnpm start
 ### Programmatic Usage
 
 ```typescript
-import { createDiscordBot } from '@agentgate/discord';
+import { createDiscordBot } from '@agentkitai/agentgate-discord';
 
 const bot = createDiscordBot({
   token: process.env.DISCORD_BOT_TOKEN!,
@@ -143,7 +143,7 @@ import {
   getUrgencyEmoji,
   getUrgencyColor,
   EMBED_COLORS,
-} from '@agentgate/discord';
+} from '@agentkitai/agentgate-discord';
 ```
 
 ## License

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/discord",
+  "name": "@agentkitai/agentgate-discord",
   "version": "0.0.3",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "dependencies": {
-    "@agentgate/core": "workspace:*",
+    "@agentkitai/agentgate-core": "workspace:*",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5"
   },

--- a/packages/discord/src/bot.ts
+++ b/packages/discord/src/bot.ts
@@ -1,4 +1,4 @@
-// @agentgate/discord - Discord bot for human approvals
+// @agentkitai/agentgate-discord - Discord bot for human approvals
 
 import {
   Client,
@@ -8,7 +8,7 @@ import {
   type TextChannel,
   type Message,
 } from "discord.js";
-import type { ApprovalRequest } from "@agentgate/core";
+import type { ApprovalRequest } from "@agentkitai/agentgate-core";
 import {
   buildApprovalEmbed,
   buildDecidedEmbed,

--- a/packages/discord/src/helpers.test.ts
+++ b/packages/discord/src/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { ApprovalRequest } from "@agentgate/core";
+import type { ApprovalRequest } from "@agentkitai/agentgate-core";
 import {
   truncate,
   formatJson,

--- a/packages/discord/src/helpers.ts
+++ b/packages/discord/src/helpers.ts
@@ -1,11 +1,11 @@
-// @agentgate/discord - Pure helper functions
+// @agentkitai/agentgate-discord - Pure helper functions
 
-import type { ApprovalRequest, ApprovalUrgency, DecisionLinks } from "@agentgate/core";
-import { truncate, formatJson, getUrgencyEmoji } from "@agentgate/core";
+import type { ApprovalRequest, ApprovalUrgency, DecisionLinks } from "@agentkitai/agentgate-core";
+import { truncate, formatJson, getUrgencyEmoji } from "@agentkitai/agentgate-core";
 import type { APIEmbed, APIEmbedField, APIActionRowComponent, APIButtonComponent } from "discord.js";
 
-export type { DecisionLinks } from "@agentgate/core";
-export { truncate, formatJson, getUrgencyEmoji } from "@agentgate/core";
+export type { DecisionLinks } from "@agentkitai/agentgate-core";
+export { truncate, formatJson, getUrgencyEmoji } from "@agentkitai/agentgate-core";
 
 /**
  * Embed colors by urgency/status

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -1,4 +1,4 @@
-// @agentgate/discord - Discord bot integration
+// @agentkitai/agentgate-discord - Discord bot integration
 
 import "dotenv/config";
 import { createDiscordBot, type DiscordBot, type DiscordBotOptions } from "./bot.js";

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,11 +1,11 @@
-# @agentgate/mcp
+# @agentkitai/agentgate-mcp
 
 MCP (Model Context Protocol) server for AgentGate. Enables Claude and other MCP-compatible AI assistants to request approvals.
 
 ## Installation
 
 ```bash
-npm install -g @agentgate/mcp
+npm install -g @agentkitai/agentgate-mcp
 ```
 
 ## Claude Desktop Configuration
@@ -17,7 +17,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "agentgate": {
       "command": "npx",
-      "args": ["@agentgate/mcp"],
+      "args": ["@agentkitai/agentgate-mcp"],
       "env": {
         "AGENTGATE_URL": "http://localhost:3000",
         "AGENTGATE_API_KEY": "your-api-key"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/mcp",
+  "name": "@agentkitai/agentgate-mcp",
   "version": "0.0.2",
   "mcpName": "io.github.agentkitai/agentgate",
   "repository": {
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@agentgate/core": "workspace:*",
+    "@agentkitai/agentgate-core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0"
   },
   "devDependencies": {

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -13,7 +13,7 @@
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "@agentgate/mcp",
+      "identifier": "@agentkitai/agentgate-mcp",
       "version": "0.0.2",
       "runtimeHint": "npx",
       "transport": {

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -1,9 +1,9 @@
 /**
  * API client for AgentGate server
  *
- * Thin wrapper around the shared AgentGateHttpClient from @agentgate/core.
+ * Thin wrapper around the shared AgentGateHttpClient from @agentkitai/agentgate-core.
  */
-import { AgentGateHttpClient } from '@agentgate/core';
+import { AgentGateHttpClient } from '@agentkitai/agentgate-core';
 import type { ApiConfig } from './types.js';
 
 /**

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @agentgate/sdk
+# @agentkitai/agentgate-sdk
 
 ## 0.1.0
 
@@ -18,7 +18,7 @@
 ### Patch Changes
 
 - Updated dependencies [e74f7b7]
-  - @agentgate/core@0.1.0
+  - @agentkitai/agentgate-core@0.1.0
 
 ## 0.0.2
 
@@ -34,4 +34,4 @@
   - AgentGateEmitter API documented in events.md
 
 - Updated dependencies [618e2da]
-  - @agentgate/core@0.0.2
+  - @agentkitai/agentgate-core@0.0.2

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,19 +1,19 @@
-# @agentgate/sdk
+# @agentkitai/agentgate-sdk
 
 TypeScript SDK for agents to request human approvals via AgentGate.
 
 ## Installation
 
 ```bash
-npm install @agentgate/sdk
+npm install @agentkitai/agentgate-sdk
 # or
-pnpm add @agentgate/sdk
+pnpm add @agentkitai/agentgate-sdk
 ```
 
 ## Quick Start
 
 ```typescript
-import { AgentGateClient } from '@agentgate/sdk'
+import { AgentGateClient } from '@agentkitai/agentgate-sdk'
 
 const client = new AgentGateClient({
   baseUrl: 'http://localhost:3000',
@@ -193,7 +193,7 @@ await client.revokeApiKey('key_123')
 ### Error Handling
 
 ```typescript
-import { AgentGateError, TimeoutError } from '@agentgate/sdk'
+import { AgentGateError, TimeoutError } from '@agentkitai/agentgate-sdk'
 
 try {
   await client.waitForDecision(id)
@@ -208,7 +208,7 @@ try {
 
 ### Types
 
-All types from `@agentgate/core` are re-exported for convenience:
+All types from `@agentkitai/agentgate-core` are re-exported for convenience:
 
 ```typescript
 import type {
@@ -226,7 +226,7 @@ import type {
   AuditListResult,
   ApiKey,
   ApiKeyCreateResult,
-} from '@agentgate/sdk'
+} from '@agentkitai/agentgate-sdk'
 ```
 
 ## License

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/sdk",
+  "name": "@agentkitai/agentgate-sdk",
   "version": "0.1.0",
   "description": "SDK for integrating AgentGate into your applications",
   "type": "module",
@@ -35,7 +35,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@agentgate/core": "workspace:*"
+    "@agentkitai/agentgate-core": "workspace:*"
   },
   "devDependencies": {
     "vitest": "^3.2.6"

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/sdk - Tests for AgentGateClient
+// @agentkitai/agentgate-sdk - Tests for AgentGateClient
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentGateClient } from './client.js';

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,6 @@
-// @agentgate/sdk - AgentGate Client
+// @agentkitai/agentgate-sdk - AgentGate Client
 
-import type { ApprovalRequest, ApprovalUrgency, Policy, PolicyRule } from '@agentgate/core';
+import type { ApprovalRequest, ApprovalUrgency, Policy, PolicyRule } from '@agentkitai/agentgate-core';
 import { AgentGateError, TimeoutError } from './errors.js';
 
 /**

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,4 +1,4 @@
-// @agentgate/sdk - Error types
+// @agentkitai/agentgate-sdk - Error types
 
 /**
  * Error thrown by AgentGate SDK operations

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,4 @@
-// @agentgate/sdk - TypeScript SDK for agents
+// @agentkitai/agentgate-sdk - TypeScript SDK for agents
 
 export const VERSION = '0.0.1';
 
@@ -38,4 +38,4 @@ export type {
   PolicyRule,
   Policy,
   PolicyDecision,
-} from '@agentgate/core';
+} from '@agentkitai/agentgate-core';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/server",
+  "name": "@agentkitai/agentgate-server",
   "version": "0.0.1",
   "type": "module",
   "main": "./dist/index.js",
@@ -32,7 +32,7 @@
     "dist"
   ],
   "dependencies": {
-    "@agentgate/core": "workspace:*",
+    "@agentkitai/agentgate-core": "workspace:*",
     "@hono/node-server": "^1.19.10",
     "@hono/zod-validator": "^0.7.6",
     "agentkit-auth": "^0.1.0",

--- a/packages/server/src/__tests__/budget-alerts.test.ts
+++ b/packages/server/src/__tests__/budget-alerts.test.ts
@@ -3,7 +3,7 @@
  * maybeAlertBudgetThreshold dedup + band selection.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { EventNames } from "@agentgate/core";
+import { EventNames } from "@agentkitai/agentgate-core";
 import type { BudgetVerdict } from "../lib/agent-budget.js";
 import { maybeAlertBudgetThreshold, resetBudgetAlerts } from "../lib/budget-alerts.js";
 import { getGlobalDispatcher } from "../lib/notification/index.js";

--- a/packages/server/src/__tests__/discord-adapter.test.ts
+++ b/packages/server/src/__tests__/discord-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import {
   DiscordAdapter,
   getEventColor,

--- a/packages/server/src/__tests__/dispatcher-unit.test.ts
+++ b/packages/server/src/__tests__/dispatcher-unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import {
   NotificationDispatcher,
   getGlobalDispatcher,

--- a/packages/server/src/__tests__/email-adapter.test.ts
+++ b/packages/server/src/__tests__/email-adapter.test.ts
@@ -24,7 +24,7 @@ vi.mock('nodemailer', () => ({
 }));
 
 import { EmailAdapter } from '../lib/notification/adapters/email.js';
-import type { AgentGateEvent } from '@agentgate/core';
+import type { AgentGateEvent } from '@agentkitai/agentgate-core';
 
 const testEvent: AgentGateEvent = {
   eventId: 'evt-1',

--- a/packages/server/src/__tests__/health.test.ts
+++ b/packages/server/src/__tests__/health.test.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Health endpoint tests
+// @agentkitai/agentgate-server - Health endpoint tests
 
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import app from "../index.js";

--- a/packages/server/src/__tests__/integration/helpers.ts
+++ b/packages/server/src/__tests__/integration/helpers.ts
@@ -13,8 +13,8 @@ import { eq, desc, and, sql, isNull } from "drizzle-orm";
 import { createHash, randomBytes } from "node:crypto";
 import isSafeRegex from "safe-regex2";
 import * as schema from "../../db/schema.js";
-import type { PolicyRule, ApprovalRequest as CoreApprovalRequest, Policy as CorePolicy } from "@agentgate/core";
-import { evaluatePolicy } from "@agentgate/core";
+import type { PolicyRule, ApprovalRequest as CoreApprovalRequest, Policy as CorePolicy } from "@agentkitai/agentgate-core";
+import { evaluatePolicy } from "@agentkitai/agentgate-core";
 
 const { approvalRequests, auditLogs, policies, apiKeys, webhooks, webhookDeliveries } = schema;
 

--- a/packages/server/src/__tests__/mcp-guardrails.test.ts
+++ b/packages/server/src/__tests__/mcp-guardrails.test.ts
@@ -41,7 +41,7 @@ vi.mock("../db/index.js", async () => ({
 import { createAgent } from "../lib/agents.js";
 import mcpRouter from "../routes/mcp.js";
 import { parseConfig, setConfig, resetConfig } from "../config.js";
-import { getGlobalEmitter, EventNames } from "@agentgate/core";
+import { getGlobalEmitter, EventNames } from "@agentkitai/agentgate-core";
 
 const TEST_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
 

--- a/packages/server/src/__tests__/notification.test.ts
+++ b/packages/server/src/__tests__/notification.test.ts
@@ -10,7 +10,7 @@ import {
   EventNames,
   type RequestCreatedEvent,
   type RequestDecidedEvent,
-} from "@agentgate/core";
+} from "@agentkitai/agentgate-core";
 import { setConfig, resetConfig, type Config } from "../config.js";
 
 // Mock the URL validator module for webhook SSRF protection

--- a/packages/server/src/__tests__/request-decision.test.ts
+++ b/packages/server/src/__tests__/request-decision.test.ts
@@ -3,7 +3,7 @@
  * This is the real decision logic the requests route runs.
  */
 import { describe, it, expect } from "vitest";
-import type { PolicyDecision } from "@agentgate/core";
+import type { PolicyDecision } from "@agentkitai/agentgate-core";
 import { decideInitialStatus } from "../lib/request-decision.js";
 
 const NOW = new Date("2026-06-22T00:00:00Z");

--- a/packages/server/src/__tests__/slack-adapter.test.ts
+++ b/packages/server/src/__tests__/slack-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import {
   SlackAdapter,
   getUrgencyEmoji,

--- a/packages/server/src/__tests__/webhook-adapter.test.ts
+++ b/packages/server/src/__tests__/webhook-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import {
   WebhookAdapter,
   signPayload,

--- a/packages/server/src/lib/agent-budget.ts
+++ b/packages/server/src/lib/agent-budget.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Per-agent budget enforcement (#13).
+// @agentkitai/agentgate-server — Per-agent budget enforcement (#13).
 //
 // Compares an agent's current-month spend (read from AgentLens via
 // lib/agent-spend) against its configured monthly USD cap. This is a SOFT

--- a/packages/server/src/lib/agent-eval.ts
+++ b/packages/server/src/lib/agent-eval.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Per-agent eval gate (#7).
+// @agentkitai/agentgate-server — Per-agent eval gate (#7).
 //
 // Reads an agent's latest eval pass-rate from AgentLens
 // (GET /api/internal/agent-eval-status; populated by the agenteval→lens
@@ -8,7 +8,7 @@
 // or the agent has no eval evidence yet, the request is allowed — never blocked
 // on a telemetry outage or an un-evaluated agent. Default-off via AGENT_EVAL_GATE.
 
-import { AgentGateHttpClient } from "@agentgate/core";
+import { AgentGateHttpClient } from "@agentkitai/agentgate-core";
 
 import { getConfig } from "../config.js";
 import { getLogger } from "./logger.js";

--- a/packages/server/src/lib/agent-spend.ts
+++ b/packages/server/src/lib/agent-spend.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Per-agent spend reads from AgentLens (#13).
+// @agentkitai/agentgate-server — Per-agent spend reads from AgentLens (#13).
 //
 // AgentGate doesn't observe LLM tokens itself; it reads priced per-agent spend
 // from AgentLens' POST /api/internal/spend (authenticated by the shared
@@ -6,7 +6,7 @@
 // checks doesn't hammer AgentLens. This is the read side; budget enforcement
 // (checkAgentBudget) builds on it.
 
-import { AgentGateHttpClient } from "@agentgate/core";
+import { AgentGateHttpClient } from "@agentkitai/agentgate-core";
 import { getConfig } from "../config.js";
 import { getLogger } from "./logger.js";
 

--- a/packages/server/src/lib/agent-token-keys.ts
+++ b/packages/server/src/lib/agent-token-keys.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Asymmetric (RS256) agent-token keys + JWKS (#40).
+// @agentkitai/agentgate-server — Asymmetric (RS256) agent-token keys + JWKS (#40).
 //
 // Optional, opt-in upgrade to the agent-identity spine. By default agent tokens
 // are signed with the shared HS256 JWT_SECRET, which every downstream verifier

--- a/packages/server/src/lib/agent-tokens.ts
+++ b/packages/server/src/lib/agent-tokens.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Agent OAuth2 token helpers (agent-identity spine).
+// @agentkitai/agentgate-server — Agent OAuth2 token helpers (agent-identity spine).
 //
 // An agent exchanges its long-lived secret (ags_*) once at the token endpoint
 // for a short-lived Bearer JWT, then presents the JWT (X-Agent-Token) instead

--- a/packages/server/src/lib/agents.ts
+++ b/packages/server/src/lib/agents.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Agent identity registry (agent-identity spine).
+// @agentkitai/agentgate-server — Agent identity registry (agent-identity spine).
 //
 // A verifiable, non-human principal. An agent is issued a public client id
 // (`agt_*`) and a secret (`ags_*`, shown once); only sha256(secret) is stored.

--- a/packages/server/src/lib/api-keys.ts
+++ b/packages/server/src/lib/api-keys.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - API key management helpers
+// @agentkitai/agentgate-server - API key management helpers
 
 import { createHash, randomBytes } from "node:crypto";
 import { nanoid } from "nanoid";

--- a/packages/server/src/lib/audit.ts
+++ b/packages/server/src/lib/audit.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Audit logging helper
+// @agentkitai/agentgate-server - Audit logging helper
 
 import { nanoid } from "nanoid";
 import { getDb, auditLogs } from "../db/index.js";

--- a/packages/server/src/lib/auth-config.ts
+++ b/packages/server/src/lib/auth-config.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Assemble the agentkit-auth AuthConfig from server config.
+// @agentkitai/agentgate-server — Assemble the agentkit-auth AuthConfig from server config.
 // Shared by the agent token endpoint and agent Bearer verification on the
 // requests route. (routes/auth.ts + middleware/auth.ts keep their own copies
 // for now; consolidating those is a separate cleanup.)

--- a/packages/server/src/lib/budget-alerts.ts
+++ b/packages/server/src/lib/budget-alerts.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Per-agent budget threshold alerts (#13 near-limit hook).
+// @agentkitai/agentgate-server — Per-agent budget threshold alerts (#13 near-limit hook).
 //
 // Fires a notification when an agent's current-month spend crosses a utilization
 // threshold (80% = near-limit warning, 100% = exceeded). Decoupled from hard
@@ -8,7 +8,7 @@
 // request. Reads spend from the same BudgetVerdict the enforcement path computes,
 // so it fails closed-to-quiet on a telemetry outage (verdict reports 0 spend).
 
-import { EventNames, createBaseEvent, type BudgetThresholdEvent } from "@agentgate/core";
+import { EventNames, createBaseEvent, type BudgetThresholdEvent } from "@agentkitai/agentgate-core";
 import type { BudgetVerdict } from "./agent-budget.js";
 import { getGlobalDispatcher } from "./notification/index.js";
 

--- a/packages/server/src/lib/escalation.ts
+++ b/packages/server/src/lib/escalation.ts
@@ -17,7 +17,7 @@ import {
   getGlobalEmitter,
   type RequestEscalatedEvent,
   type RequestDecidedEvent,
-} from "@agentgate/core";
+} from "@agentkitai/agentgate-core";
 
 /** Parse an escalateTo of the form `decision:approve` / `decision:deny`. */
 function parseFallbackDecision(escalateTo: string): "approved" | "denied" | null {

--- a/packages/server/src/lib/lens-breach.ts
+++ b/packages/server/src/lib/lens-breach.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Mirror guardrail breaches into AgentLens (#55, gate→lens wedge).
+// @agentkitai/agentgate-server — Mirror guardrail breaches into AgentLens (#55, gate→lens wedge).
 //
 // When the gate denies an action, we record it in AgentLens as a hash-chained
 // compliance eval_result, so the breach becomes tamper-evident audit evidence.
@@ -7,7 +7,7 @@
 // holds no AgentLens session of its own, so the caller supplies the sessionId it
 // observed the breach in (omit → no-op, since there's no chain to extend).
 
-import { AgentGateHttpClient } from "@agentgate/core";
+import { AgentGateHttpClient } from "@agentkitai/agentgate-core";
 import { getConfig } from "../config.js";
 import { getLogger } from "./logger.js";
 

--- a/packages/server/src/lib/mcp-guardrails.ts
+++ b/packages/server/src/lib/mcp-guardrails.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — MCP tool-call guardrails (issue #14).
+// @agentkitai/agentgate-server — MCP tool-call guardrails (issue #14).
 //
 // Enforce per-agent tool allow-listing at the MCP protocol boundary, right
 // before a tool executes. Reuses the agent-identity spine (#12): the gate is
@@ -17,7 +17,7 @@ import {
   createBaseEvent,
   getGlobalEmitter,
   type RequestCreatedEvent,
-} from "@agentgate/core";
+} from "@agentkitai/agentgate-core";
 
 import { getDb, approvalRequests } from "../db/index.js";
 import { checkOverrides } from "../routes/overrides.js";

--- a/packages/server/src/lib/notification/adapters/discord.ts
+++ b/packages/server/src/lib/notification/adapters/discord.ts
@@ -5,7 +5,7 @@
  * Uses embeds for rich message formatting.
  */
 
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import type { NotificationChannelAdapter, NotificationResult } from "../types.js";
 import { getConfig } from "../../../config.js";
 

--- a/packages/server/src/lib/notification/adapters/email.ts
+++ b/packages/server/src/lib/notification/adapters/email.ts
@@ -6,13 +6,13 @@
  * and includes one-click action links in the email.
  */
 
-import type { AgentGateEvent, RequestCreatedEvent, DecisionLinks } from "@agentgate/core";
-import { getUrgencyEmoji, formatJson, escapeHtml } from "@agentgate/core";
+import type { AgentGateEvent, RequestCreatedEvent, DecisionLinks } from "@agentkitai/agentgate-core";
+import { getUrgencyEmoji, formatJson, escapeHtml } from "@agentkitai/agentgate-core";
 import type { NotificationChannelAdapter, NotificationResult } from "../types.js";
 import { getConfig } from "../../../config.js";
 import { generateDecisionTokens } from "../../decision-tokens.js";
 
-export type { DecisionLinks } from "@agentgate/core";
+export type { DecisionLinks } from "@agentkitai/agentgate-core";
 
 // ============================================================================
 // Decision Link Generation

--- a/packages/server/src/lib/notification/adapters/slack.ts
+++ b/packages/server/src/lib/notification/adapters/slack.ts
@@ -5,14 +5,14 @@
  * Uses Block Kit for rich message formatting.
  */
 
-import type { AgentGateEvent, DecisionLinks } from "@agentgate/core";
-import { getUrgencyEmoji, formatJson } from "@agentgate/core";
+import type { AgentGateEvent, DecisionLinks } from "@agentkitai/agentgate-core";
+import { getUrgencyEmoji, formatJson } from "@agentkitai/agentgate-core";
 import type { NotificationChannelAdapter, NotificationResult } from "../types.js";
 import { getConfig } from "../../../config.js";
 import { generateDecisionTokens } from "../../decision-tokens.js";
 
-export type { DecisionLinks } from "@agentgate/core";
-export { getUrgencyEmoji, formatJson } from "@agentgate/core";
+export type { DecisionLinks } from "@agentkitai/agentgate-core";
+export { getUrgencyEmoji, formatJson } from "@agentkitai/agentgate-core";
 
 /**
  * Options for building Slack blocks

--- a/packages/server/src/lib/notification/adapters/webhook.ts
+++ b/packages/server/src/lib/notification/adapters/webhook.ts
@@ -6,7 +6,7 @@
  */
 
 import crypto from "crypto";
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import type { NotificationChannelAdapter, NotificationResult } from "../types.js";
 import { getConfig } from "../../../config.js";
 import { validateWebhookUrl } from "../../url-validator.js";

--- a/packages/server/src/lib/notification/dispatcher.ts
+++ b/packages/server/src/lib/notification/dispatcher.ts
@@ -12,7 +12,7 @@ import {
   type EventName,
   type ApprovalUrgency,
   eventMatchesFilter,
-} from "@agentgate/core";
+} from "@agentkitai/agentgate-core";
 import type {
   ChannelRoute,
   NotificationChannelAdapter,

--- a/packages/server/src/lib/notification/types.ts
+++ b/packages/server/src/lib/notification/types.ts
@@ -2,7 +2,7 @@
  * Notification system types
  */
 
-import type { AgentGateEvent, ApprovalUrgency } from "@agentgate/core";
+import type { AgentGateEvent, ApprovalUrgency } from "@agentkitai/agentgate-core";
 
 /**
  * Supported notification channel types

--- a/packages/server/src/lib/owasp.ts
+++ b/packages/server/src/lib/owasp.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — OWASP LLM Top-10 (2025) risk tagging for the audit trail.
+// @agentkitai/agentgate-server — OWASP LLM Top-10 (2025) risk tagging for the audit trail.
 //
 // Tagging each policy decision with the OWASP LLM risk it addresses turns the
 // approval audit log into compliance evidence (filterable/exportable per risk).

--- a/packages/server/src/lib/policy-cache.ts
+++ b/packages/server/src/lib/policy-cache.ts
@@ -6,7 +6,7 @@
  */
 
 import { getDb, policies } from "../db/index.js";
-import type { Policy as CorePolicy, PolicyRule } from "@agentgate/core";
+import type { Policy as CorePolicy, PolicyRule } from "@agentkitai/agentgate-core";
 
 let cachedPolicies: CorePolicy[] | null = null;
 let inflight: Promise<CorePolicy[]> | null = null;

--- a/packages/server/src/lib/policy-templates.ts
+++ b/packages/server/src/lib/policy-templates.ts
@@ -1,6 +1,6 @@
-// @agentgate/server - Risk-Aware Policy Templates
+// @agentkitai/agentgate-server - Risk-Aware Policy Templates
 
-import type { PolicyRule } from "@agentgate/core";
+import type { PolicyRule } from "@agentkitai/agentgate-core";
 
 export interface PolicyTemplate {
   id: string;

--- a/packages/server/src/lib/rate-limiter.ts
+++ b/packages/server/src/lib/rate-limiter.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Rate limiter (legacy re-exports)
+// @agentkitai/agentgate-server - Rate limiter (legacy re-exports)
 // This file is kept for backwards compatibility
 // New code should import from ./rate-limiter/index.js
 

--- a/packages/server/src/lib/rate-limiter/index.ts
+++ b/packages/server/src/lib/rate-limiter/index.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Rate limiter module
+// @agentkitai/agentgate-server - Rate limiter module
 
 export type { RateLimiter, RateLimitResult, RateLimiterBackend } from "./types.js";
 export { InMemoryRateLimiter } from "./memory.js";

--- a/packages/server/src/lib/rate-limiter/memory.ts
+++ b/packages/server/src/lib/rate-limiter/memory.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - In-memory sliding window rate limiter
+// @agentkitai/agentgate-server - In-memory sliding window rate limiter
 
 import type { RateLimiter, RateLimitResult } from "./types.js";
 

--- a/packages/server/src/lib/rate-limiter/redis.ts
+++ b/packages/server/src/lib/rate-limiter/redis.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Redis-backed sliding window rate limiter
+// @agentkitai/agentgate-server - Redis-backed sliding window rate limiter
 
 import Redis from "ioredis";
 import type { RateLimiter, RateLimitResult } from "./types.js";

--- a/packages/server/src/lib/rate-limiter/types.ts
+++ b/packages/server/src/lib/rate-limiter/types.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Rate limiter types and interface
+// @agentkitai/agentgate-server - Rate limiter types and interface
 
 /**
  * Result of a rate limit check

--- a/packages/server/src/lib/rbac.ts
+++ b/packages/server/src/lib/rbac.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — RBAC permission model for AgentGate
+// @agentkitai/agentgate-server — RBAC permission model for AgentGate
 //
 // Extends agentkit-auth's generic RBAC with AgentGate-specific permissions.
 

--- a/packages/server/src/lib/request-decision.ts
+++ b/packages/server/src/lib/request-decision.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Initial decision for a new approval request.
+// @agentkitai/agentgate-server — Initial decision for a new approval request.
 //
 // Precedence (highest first): a per-agent budget overage (#13) denies outright,
 // then the per-agent eval gate (#7) denies outright, then a dynamic override
@@ -6,7 +6,7 @@
 // else stays pending. Extracted as a pure function so the precedence is
 // unit-testable without driving the whole request route.
 
-import type { PolicyDecision } from "@agentgate/core";
+import type { PolicyDecision } from "@agentkitai/agentgate-core";
 
 export interface InitialDecision {
   status: "pending" | "approved" | "denied";

--- a/packages/server/src/lib/spiffe.ts
+++ b/packages/server/src/lib/spiffe.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Accept an external SPIFFE JWT-SVID as a verified principal (#41).
+// @agentkitai/agentgate-server — Accept an external SPIFFE JWT-SVID as a verified principal (#41).
 //
 // Enterprises that already run a SPIFFE/SPIRE (or WIMSE) workload-identity plane
 // can present a JWT-SVID instead of minting an AgentGate agent token. AgentGate

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Authentication & authorization middleware
+// @agentkitai/agentgate-server - Authentication & authorization middleware
 //
 // Dual-mode auth: API key (agk_*) and OIDC JWT.
 // Uses agentkit-auth middleware factory for JWT handling.

--- a/packages/server/src/middleware/security-headers.ts
+++ b/packages/server/src/middleware/security-headers.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Security headers middleware
+// @agentkitai/agentgate-server - Security headers middleware
 
 import type { Context, Next } from "hono";
 import { getConfig } from "../config.js";

--- a/packages/server/src/routes/agent-tokens.ts
+++ b/packages/server/src/routes/agent-tokens.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Agent OAuth2 token endpoint (agent-identity spine).
+// @agentkitai/agentgate-server — Agent OAuth2 token endpoint (agent-identity spine).
 //
 // POST /api/agents/token — RFC 6749 client_credentials grant. An agent presents
 // its agt_*/ags_* credential (JSON body or HTTP Basic) and receives a

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Agent registry routes (agent-identity spine).
+// @agentkitai/agentgate-server — Agent registry routes (agent-identity spine).
 // CRUD for non-human agent principals. Admin-only (credential management).
 
 import { Hono } from "hono";

--- a/packages/server/src/routes/analytics.ts
+++ b/packages/server/src/routes/analytics.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Analytics & Governance KPI routes
+// @agentkitai/agentgate-server - Analytics & Governance KPI routes
 
 import { Hono } from "hono";
 import { and, gte, lte, sql, eq, type SQL } from "drizzle-orm";

--- a/packages/server/src/routes/audit.ts
+++ b/packages/server/src/routes/audit.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Audit log API routes
+// @agentkitai/agentgate-server - Audit log API routes
 
 import { Hono } from "hono";
 import { eq, and, gte, lte, desc, sql, type SQL } from "drizzle-orm";

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — OIDC auth routes
+// @agentkitai/agentgate-server — OIDC auth routes
 //
 // GET  /auth/mode      → Return current AUTH_MODE for dashboard detection
 // POST /auth/login     → Initiate OIDC login (returns redirect URL)

--- a/packages/server/src/routes/channels.ts
+++ b/packages/server/src/routes/channels.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import { getGlobalDispatcher } from "../lib/notification/dispatcher.js";
 import { getHealthTracker } from "../lib/notification/health.js";
-import type { AgentGateEvent } from "@agentgate/core";
+import type { AgentGateEvent } from "@agentkitai/agentgate-core";
 import { randomUUID } from "node:crypto";
 
 const router = new Hono();

--- a/packages/server/src/routes/decide.ts
+++ b/packages/server/src/routes/decide.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Public decision endpoint for one-click approve/deny
+// @agentkitai/agentgate-server - Public decision endpoint for one-click approve/deny
 
 import { Hono } from "hono";
 import { html } from "hono/html";

--- a/packages/server/src/routes/escalations.ts
+++ b/packages/server/src/routes/escalations.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Escalation rules and history routes
+// @agentkitai/agentgate-server - Escalation rules and history routes
 
 import { Hono } from "hono";
 import { nanoid } from "nanoid";

--- a/packages/server/src/routes/guardrails.ts
+++ b/packages/server/src/routes/guardrails.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Reactive guardrails
+// @agentkitai/agentgate-server — Reactive guardrails
 //
 // Folds in the former standalone `agentkit-guardrails` service. AgentLens monitors
 // agent metrics (error rate, latency, token usage, …) and POSTs a breach/recovery

--- a/packages/server/src/routes/internal.ts
+++ b/packages/server/src/routes/internal.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Internal service-to-service routes (#24).
+// @agentkitai/agentgate-server — Internal service-to-service routes (#24).
 //
 // POST /api/internal/verify-ingest-key — AgentLens calls this to resolve the
 // verified agent id for an OTLP ingest key it received. Authenticated by the

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — MCP guardrail endpoint (issue #14).
+// @agentkitai/agentgate-server — MCP guardrail endpoint (issue #14).
 // POST /api/mcp/authorize — the MCP server calls this before executing a tool.
 // Mounted behind the normal /api/* auth middleware, so the caller's api key
 // (and any virtual-key agent binding, #13) is available on the context.

--- a/packages/server/src/routes/overrides.ts
+++ b/packages/server/src/routes/overrides.ts
@@ -1,9 +1,9 @@
-// @agentgate/server - Override routes for dynamic policy overrides
+// @agentkitai/agentgate-server - Override routes for dynamic policy overrides
 
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
 import { eq, and, gt, lt, isNull, or, not } from "drizzle-orm";
-import type { OverrideAction } from "@agentgate/core";
+import type { OverrideAction } from "@agentkitai/agentgate-core";
 import { getDb, overrides } from "../db/index.js";
 
 const overridesRouter = new Hono();

--- a/packages/server/src/routes/policies.ts
+++ b/packages/server/src/routes/policies.ts
@@ -1,12 +1,12 @@
-// @agentgate/server - Policy routes
+// @agentkitai/agentgate-server - Policy routes
 
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
 import { eq, sql, and, gte, lte } from "drizzle-orm";
 import isSafeRegex from "safe-regex2";
 import { getDb, policies, approvalRequests } from "../db/index.js";
-import type { PolicyRule, Policy, PolicyScope, ApprovalRequest } from "@agentgate/core";
-import { evaluatePolicy } from "@agentgate/core";
+import type { PolicyRule, Policy, PolicyScope, ApprovalRequest } from "@agentkitai/agentgate-core";
+import { evaluatePolicy } from "@agentkitai/agentgate-core";
 import { invalidatePolicyCache } from "../lib/policy-cache.js";
 import { getTemplates, getTemplateById } from "../lib/policy-templates.js";
 

--- a/packages/server/src/routes/requests.ts
+++ b/packages/server/src/routes/requests.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Approval request routes
+// @agentkitai/agentgate-server - Approval request routes
 
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
@@ -13,7 +13,7 @@ import {
   type Policy as CorePolicy,
   type RequestCreatedEvent,
   type RequestDecidedEvent,
-} from "@agentgate/core";
+} from "@agentkitai/agentgate-core";
 import { logAuditEvent } from "../lib/audit.js";
 import { owaspRiskForPolicyDecision } from "../lib/owasp.js";
 import { resolveVerifiedAgentId, resolveEffectiveAgentId } from "../lib/agent-tokens.js";

--- a/packages/server/src/routes/tokens.ts
+++ b/packages/server/src/routes/tokens.ts
@@ -1,4 +1,4 @@
-// @agentgate/server - Decision token routes
+// @agentkitai/agentgate-server - Decision token routes
 
 import { Hono } from "hono";
 import { nanoid } from "nanoid";

--- a/packages/server/src/routes/well-known.ts
+++ b/packages/server/src/routes/well-known.ts
@@ -1,4 +1,4 @@
-// @agentgate/server — Public JWKS for asymmetric agent tokens (#40).
+// @agentkitai/agentgate-server — Public JWKS for asymmetric agent tokens (#40).
 //
 // GET /.well-known/jwks.json — the PUBLIC half of the RS256 agent-token signing
 // key(s). Downstream verifiers (AgentLens, Lore) fetch this to verify agent

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -1,4 +1,4 @@
-# @agentgate/slack
+# @agentkitai/agentgate-slack
 
 Slack bot integration for AgentGate human approvals.
 
@@ -12,7 +12,7 @@ Slack bot integration for AgentGate human approvals.
 ## Installation
 
 ```bash
-pnpm add @agentgate/slack
+pnpm add @agentkitai/agentgate-slack
 ```
 
 ## Slack App Setup
@@ -58,7 +58,7 @@ After installation, you'll need:
 ### As a Library
 
 ```typescript
-import { createSlackBot } from '@agentgate/slack';
+import { createSlackBot } from '@agentkitai/agentgate-slack';
 
 const bot = createSlackBot({
   token: process.env.SLACK_BOT_TOKEN!,

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentgate/slack",
+  "name": "@agentkitai/agentgate-slack",
   "version": "0.0.1",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "dependencies": {
-    "@agentgate/core": "workspace:*",
+    "@agentkitai/agentgate-core": "workspace:*",
     "@slack/bolt": "^4.1.0",
     "@slack/types": "^2.19.0",
     "dotenv": "^16.4.5"

--- a/packages/slack/src/bot.test.ts
+++ b/packages/slack/src/bot.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ApprovalRequest } from '@agentgate/core';
+import type { ApprovalRequest } from '@agentkitai/agentgate-core';
 
 // Mock @slack/bolt before importing bot
 const mockStart = vi.fn();

--- a/packages/slack/src/bot.ts
+++ b/packages/slack/src/bot.ts
@@ -1,7 +1,7 @@
-// @agentgate/slack - Slack bot for human approvals
+// @agentkitai/agentgate-slack - Slack bot for human approvals
 
 import { App, type BlockAction } from '@slack/bolt';
-import type { ApprovalRequest } from '@agentgate/core';
+import type { ApprovalRequest } from '@agentkitai/agentgate-core';
 import { buildApprovalBlocks, buildDecidedBlocks } from './helpers.js';
 
 export interface SlackBotOptions {

--- a/packages/slack/src/helpers.test.ts
+++ b/packages/slack/src/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { ApprovalRequest } from '@agentgate/core';
+import type { ApprovalRequest } from '@agentkitai/agentgate-core';
 import {
   truncate,
   formatJson,

--- a/packages/slack/src/helpers.ts
+++ b/packages/slack/src/helpers.ts
@@ -1,11 +1,11 @@
-// @agentgate/slack - Pure helper functions
+// @agentkitai/agentgate-slack - Pure helper functions
 
 import type { KnownBlock } from '@slack/types';
-import type { ApprovalRequest, DecisionLinks } from '@agentgate/core';
-import { truncate, formatJson, getUrgencyEmoji } from '@agentgate/core';
+import type { ApprovalRequest, DecisionLinks } from '@agentkitai/agentgate-core';
+import { truncate, formatJson, getUrgencyEmoji } from '@agentkitai/agentgate-core';
 
-export type { DecisionLinks } from '@agentgate/core';
-export { truncate, formatJson, getUrgencyEmoji } from '@agentgate/core';
+export type { DecisionLinks } from '@agentkitai/agentgate-core';
+export { truncate, formatJson, getUrgencyEmoji } from '@agentkitai/agentgate-core';
 
 /**
  * Options for building approval blocks

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,4 +1,4 @@
-// @agentgate/slack - Slack bot integration
+// @agentkitai/agentgate-slack - Slack bot integration
 
 import 'dotenv/config';
 import { createSlackBot, type SlackBot, type SlackBotOptions } from './bot.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
 
   apps/demo:
     dependencies:
-      '@agentgate/sdk':
+      '@agentkitai/agentgate-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
     devDependencies:
@@ -91,7 +91,7 @@ importers:
 
   packages/cli:
     dependencies:
-      '@agentgate/core':
+      '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
       commander:
@@ -117,7 +117,7 @@ importers:
 
   packages/dashboard:
     dependencies:
-      '@agentgate/core':
+      '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
       react:
@@ -157,7 +157,7 @@ importers:
 
   packages/discord:
     dependencies:
-      '@agentgate/core':
+      '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
       discord.js:
@@ -179,7 +179,7 @@ importers:
 
   packages/mcp:
     dependencies:
-      '@agentgate/core':
+      '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
       '@modelcontextprotocol/sdk':
@@ -198,7 +198,7 @@ importers:
 
   packages/sdk:
     dependencies:
-      '@agentgate/core':
+      '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
     devDependencies:
@@ -208,7 +208,7 @@ importers:
 
   packages/server:
     dependencies:
-      '@agentgate/core':
+      '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
       '@hono/node-server':
@@ -281,7 +281,7 @@ importers:
 
   packages/slack:
     dependencies:
-      '@agentgate/core':
+      '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
       '@slack/bolt':


### PR DESCRIPTION
Part of #96 — npm scope migration, **repo 2 of 3**. `@agentgate/*` → `@agentkitai/agentgate-*` (core/cli/sdk/dashboard/discord/mcp/server/slack + private demo/action/root).

- All names + internal deps + import specifiers + the changesets ignore-list updated in lockstep (**138 files**); lockfile regenerated; **full build passes**.
- The external `agentkit-auth ^0.1.0` dep is **intentionally left as-is** — `@agentkitai/auth` (renamed in agentlens) isn't on npm yet, so repointing now would break install. A follow-up updates it once that publishes.
- Bin names (`agentgate`, `agentgate-mcp`) frozen.

Registry steps owner-gated: first-publish + Trusted Publisher (release.yml; publish-mcp.yml for `@agentkitai/agentgate-mcp`) + deprecate the 8 old names; cut a fresh `mcp-v*` tag so the MCP Registry listing updates.