### PR TITLE
chore: repoint agentkit-auth → @agentkitai/auth + fix stale repo URLs (#96)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/amitpaz1/agentgate.git",
+    "url": "https://github.com/agentkitai/agentgate.git",
     "directory": "packages/cli"
   },
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/amitpaz1/agentgate.git",
+    "url": "https://github.com/agentkitai/agentgate.git",
     "directory": "packages/core"
   },
   "keywords": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/amitpaz1/agentgate.git",
+    "url": "https://github.com/agentkitai/agentgate.git",
     "directory": "packages/sdk"
   },
   "keywords": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,7 +35,7 @@
     "@agentkitai/agentgate-core": "workspace:*",
     "@hono/node-server": "^1.19.10",
     "@hono/zod-validator": "^0.7.6",
-    "agentkit-auth": "^0.1.0",
+    "@agentkitai/auth": "^0.1.0",
     "better-sqlite3": "^11.6.0",
     "dotenv": "^16.4.0",
     "drizzle-orm": "^0.45.2",

--- a/packages/server/src/__tests__/agent-identity-e2e.test.ts
+++ b/packages/server/src/__tests__/agent-identity-e2e.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { signAccessToken, type AuthConfig } from "agentkit-auth";
+import { signAccessToken, type AuthConfig } from "@agentkitai/auth";
 import { createTestDb } from "./setup.js";
 
 const WRONG_SECRET = "a-totally-different-secret-32-chars-xx";

--- a/packages/server/src/__tests__/agent-token-asymmetric.test.ts
+++ b/packages/server/src/__tests__/agent-token-asymmetric.test.ts
@@ -20,7 +20,7 @@ import {
   type JWK,
   type CryptoKey as JoseCryptoKey,
 } from "jose";
-import { type AuthConfig } from "agentkit-auth";
+import { type AuthConfig } from "@agentkitai/auth";
 import * as schema from "../db/schema.js";
 
 // agent-tokens.ts → agents.js → db/index.js at import time; stub the DB (these

--- a/packages/server/src/__tests__/agent-tokens.test.ts
+++ b/packages/server/src/__tests__/agent-tokens.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
 import { Hono } from "hono";
-import { signAccessToken, type AuthConfig } from "agentkit-auth";
+import { signAccessToken, type AuthConfig } from "@agentkitai/auth";
 import { generateKeyPair, exportJWK, SignJWT, type JWK } from "jose";
 import * as schema from "../db/schema.js";
 

--- a/packages/server/src/lib/agent-tokens.ts
+++ b/packages/server/src/lib/agent-tokens.ts
@@ -8,7 +8,7 @@
 // session (and vice versa) — verifyAccessToken only checks the signature, not
 // the claim, so this check is load-bearing and must not be dropped.
 
-import { signAccessToken, verifyAccessToken, type AuthConfig } from "agentkit-auth";
+import { signAccessToken, verifyAccessToken, type AuthConfig } from "@agentkitai/auth";
 import { SignJWT, jwtVerify, decodeProtectedHeader } from "jose";
 
 import { getAgentIfActive, verifyAgentCredential } from "./agents.js";

--- a/packages/server/src/lib/auth-config.ts
+++ b/packages/server/src/lib/auth-config.ts
@@ -4,7 +4,7 @@
 // for now; consolidating those is a separate cleanup.)
 
 import { getConfig, resolveJwtSecret } from "../config.js";
-import type { AuthConfig } from "agentkit-auth";
+import type { AuthConfig } from "@agentkitai/auth";
 
 export function getAuthConfig(): AuthConfig {
   const config = getConfig();

--- a/packages/server/src/lib/rbac.ts
+++ b/packages/server/src/lib/rbac.ts
@@ -2,7 +2,7 @@
 //
 // Extends agentkit-auth's generic RBAC with AgentGate-specific permissions.
 
-import type { Role } from 'agentkit-auth';
+import type { Role } from '@agentkitai/auth';
 
 /**
  * AgentGate-specific permissions

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -13,7 +13,7 @@ import {
   verifyAccessToken,
   type AuthConfig,
   type Role,
-} from "agentkit-auth";
+} from "@agentkitai/auth";
 import {
   type AgentGatePermission,
   mapScopesToPermissions,

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -18,7 +18,7 @@ import {
   hashToken,
   type AuthConfig,
   type Role,
-} from "agentkit-auth";
+} from "@agentkitai/auth";
 import { getLogger } from "../lib/logger.js";
 import type { AgentGateAuthContext } from "../middleware/auth.js";
 import { randomBytes } from "node:crypto";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,15 +211,15 @@ importers:
       '@agentkitai/agentgate-core':
         specifier: workspace:*
         version: link:../core
+      '@agentkitai/auth':
+        specifier: ^0.1.0
+        version: 0.1.0(hono@4.12.26)
       '@hono/node-server':
         specifier: ^1.19.10
         version: 1.19.14(hono@4.12.26)
       '@hono/zod-validator':
         specifier: ^0.7.6
         version: 0.7.6(hono@4.12.26)(zod@4.3.6)
-      agentkit-auth:
-        specifier: ^0.1.0
-        version: 0.1.0(hono@4.12.26)
       better-sqlite3:
         specifier: ^11.6.0
         version: 11.10.0
@@ -323,6 +323,11 @@ packages:
 
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+
+  '@agentkitai/auth@0.1.0':
+    resolution: {integrity: sha512-tzAHfUJFEDMrPO78ICiKe/ll6II3Keb/MgMWYtBbIdkDB/U87XYbuEYC9l64YTFsYL4RjGIqMg24+o7749tVPw==}
+    peerDependencies:
+      hono: ^4.0.0
 
   '@algolia/abtesting@1.13.0':
     resolution: {integrity: sha512-Zrqam12iorp3FjiKMXSTpedGYznZ3hTEOAr2oCxI8tbF8bS1kQHClyDYNq/eV0ewMNLyFkgZVWjaS+8spsOYiQ==}
@@ -1929,11 +1934,6 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
-
-  agentkit-auth@0.1.0:
-    resolution: {integrity: sha512-gW25jh0tMC8XKjxeJl4Ny3C1z9aaDDofrHuHshpUryI8Gip6OG0sWhjLAaybi57uHurGuqQ5WN3uSYY7iE6gmQ==}
-    peerDependencies:
-      hono: ^4.0.0
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -4231,6 +4231,12 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
+  '@agentkitai/auth@0.1.0(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+      jose: 6.1.3
+      openid-client: 6.8.2
+
   '@algolia/abtesting@1.13.0':
     dependencies:
       '@algolia/client-common': 5.47.0
@@ -5838,12 +5844,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  agentkit-auth@0.1.0(hono@4.12.26):
-    dependencies:
-      hono: 4.12.26
-      jose: 6.1.3
-      openid-client: 6.8.2
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:


### PR DESCRIPTION
#96 follow-up. The scope migration (#53) left agentgate-server's external `agentkit-auth ^0.1.0` dep as-is because `@agentkitai/auth` wasn't published yet. It's live now (same package, renamed), so:
- **packages/server**: dep + all 9 `agentkit-auth` import sites → `@agentkitai/auth`.
- Fixed stale `github.com/amitpaz1/agentgate` repository URLs (cli/core/sdk) → `agentkitai/agentgate`.

Lockfile regenerated; server builds against the published `@agentkitai/auth`.