### PR TITLE
docs: fix staleness across agentgate docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,11 +13,11 @@ NODE_ENV=production
 # -----------------------------------------------------------------------------
 # Server Configuration
 # -----------------------------------------------------------------------------
-# Port for the API server (internal container port is always 3000)
-SERVER_PORT=3000
+# Host port to publish the API server on (container internal port is always 3000)
+SERVER_PORT=3002
 
-# Port for the dashboard (internal container port is always 80)
-DASHBOARD_PORT=8080
+# Host port to publish the dashboard on (container internal port is always 80)
+DASHBOARD_PORT=3003
 
 # -----------------------------------------------------------------------------
 # Security (required)
@@ -33,7 +33,7 @@ JWT_SECRET=
 
 # Allowed CORS origins (comma-separated)
 # Use * for development, restrict in production
-CORS_ORIGINS=*
+CORS_ALLOWED_ORIGINS=*
 
 # -----------------------------------------------------------------------------
 # PostgreSQL Database

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -82,7 +82,7 @@ DATABASE_URL=postgresql://user:pass@db.example.com:5432/agentgate?sslmode=requir
 |----------|------|---------|-------------|
 | `ADMIN_API_KEY` | string | - | Admin API key (min 16 chars, required in production) |
 | `JWT_SECRET` | string | - | JWT signing secret (min 32 chars, recommended in production) |
-| `CORS_ORIGINS` | string | `*` | Allowed CORS origins (comma-separated) |
+| `CORS_ALLOWED_ORIGINS` | string | `*` | Allowed CORS origins (comma-separated) |
 
 ### Rate Limiting
 
@@ -321,7 +321,7 @@ DATABASE_URL=/var/data/agentgate.db
 # Security
 ADMIN_API_KEY=your-secure-admin-key-here
 JWT_SECRET=your-secure-jwt-secret-at-least-32-characters
-CORS_ORIGINS=https://app.example.com,https://admin.example.com
+CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 
 # Rate Limiting
 RATE_LIMIT_ENABLED=true
@@ -351,7 +351,7 @@ When running in production (`NODE_ENV=production`), ensure:
 
 - [ ] `ADMIN_API_KEY` is set (minimum 16 characters)
 - [ ] `JWT_SECRET` is set (minimum 32 characters)
-- [ ] `CORS_ORIGINS` is restricted (not `*`)
+- [ ] `CORS_ALLOWED_ORIGINS` is restricted (not `*`)
 - [ ] `DATABASE_URL` points to a persistent location
 - [ ] `LOG_FORMAT=json` for structured logging
 - [ ] Rate limiting is enabled

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ auto-deny dangerous ones, and route everything else to a human — via dashboard
 docker compose up
 
 # …or from source:
-pnpm install && pnpm migrate && pnpm bootstrap && pnpm dev
+pnpm install && pnpm --filter @agentkitai/agentgate-server db:migrate && pnpm --filter @agentkitai/agentgate-server bootstrap && pnpm dev
 ```
 
 Drop AgentGate into an MCP client (Claude Desktop / Cursor / VS Code) — point it at the gateway:
@@ -640,7 +640,7 @@ All configuration is done via environment variables. See `.env.example` for all 
 
 **Recommended for production:**
 - `JWT_SECRET` — JWT signing secret (min 32 characters)
-- `CORS_ORIGINS` — Restrict to your domain(s)
+- `CORS_ALLOWED_ORIGINS` — Restrict to your domain(s)
 - `POSTGRES_PASSWORD` — Use a strong password
 
 ### Building Images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       # Security
       ADMIN_API_KEY: ${ADMIN_API_KEY:?ADMIN_API_KEY is required}
       JWT_SECRET: ${JWT_SECRET:-}
-      CORS_ORIGINS: ${CORS_ORIGINS:-*}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-*}
       
       # Rate Limiting
       RATE_LIMIT_ENABLED: ${RATE_LIMIT_ENABLED:-true}

--- a/docs/api.md
+++ b/docs/api.md
@@ -447,7 +447,7 @@ DELETE /api/webhooks/:id
 
 ## Request Body Size Limits
 
-All endpoints that accept a request body enforce a size limit (default: **100KB**). Requests exceeding this limit receive a `413 Payload Too Large` response. Configure via the `BODY_SIZE_LIMIT` environment variable (see [Configuration](/configuration)).
+All endpoints that accept a request body enforce a fixed size limit of **1 MB**. This limit is hard-coded and not configurable via an environment variable. Requests exceeding this limit receive a `413 Payload Too Large` response.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,6 @@ DATABASE_URL=postgresql://user:pass@db.example.com:5432/agentgate?sslmode=requir
 | `CORS_ALLOWED_ORIGINS` | string | `*` | Allowed CORS origins (comma-separated) |
 | `HSTS_ENABLED` | boolean | `false` | Enable HTTP Strict Transport Security header |
 | `WEBHOOK_ENCRYPTION_KEY` | string | - | AES-256-GCM key for encrypting webhook secrets at rest |
-| `BODY_SIZE_LIMIT` | string | `100kb` | Maximum request body size (e.g., `100kb`, `1mb`) |
 
 ::: danger Production Requirements
 In production (`NODE_ENV=production`), `ADMIN_API_KEY` is required and must be at least 16 characters.
@@ -203,7 +202,6 @@ SLACK_DEFAULT_CHANNEL=#agentgate-alerts
 # Security (additional)
 HSTS_ENABLED=true
 WEBHOOK_ENCRYPTION_KEY=your-32-byte-hex-key
-BODY_SIZE_LIMIT=100kb
 
 # Cleanup
 CLEANUP_RETENTION_DAYS=30


### PR DESCRIPTION
Fixes verified doc-staleness issues from the audit pass:

- **CORS env var name**: docs referenced `CORS_ORIGINS`, but the server reads `CORS_ALLOWED_ORIGINS` (packages/server/src/config.ts ENV_MAP). Renamed in docker-compose.yml, .env.example, README.md, and CONFIG.md (table, example .env, production checklist).
- **README Quickstart**: `pnpm migrate` / `pnpm bootstrap` are not real scripts. Replaced with `pnpm --filter @agentkitai/agentgate-server db:migrate` and `... bootstrap`.
- **.env.example ports**: `SERVER_PORT` 3000→3002 and `DASHBOARD_PORT` 8080→3003 to match docker-compose host-port defaults; clarified these are HOST ports (container internal ports are fixed 3000/80).
- **Body size limit**: it is a fixed 1 MB (packages/server/src/index.ts `bodyLimit({ maxSize: 1024*1024 })`), not configurable via `BODY_SIZE_LIMIT`. Reworded docs/api.md and removed the `BODY_SIZE_LIMIT` row + example from docs/configuration.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01CKkfVA3iY5G3Q43Mg4Xsu2