### PR TITLE
feat(webhooks): dev-mode allowPrivate escape hatch for the SSRF guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,12 @@ WEBHOOK_TIMEOUT_MS=5000
 # Maximum webhook retry attempts
 WEBHOOK_MAX_RETRIES=3
 
+# DEV/TEST ONLY — allow webhook destinations on loopback / private IP ranges
+# (127.0.0.1, ::1, 10.x, 172.16-31.x, 192.168.x, localhost) so local integrations
+# can register a http://127.0.0.1:PORT webhook. Cloud metadata endpoints and
+# non-HTTP(S) protocols stay blocked. Default off. NEVER enable in production.
+# AGENTGATE_ALLOW_PRIVATE_WEBHOOKS=1
+
 # Timeout (ms) for ALL AgentLens spend reads (budget path + GET /agents/:id/spend).
 # Kept short so a slow AgentLens can't add tail latency to POST /api/requests;
 # raise it if AgentLens is far/slow and informational spend reads start to 502.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -109,6 +109,7 @@ recovery. AgentLens posts to `POST /api/guardrails/webhook` with a shared secret
 | `REQUEST_TIMEOUT_SEC` | number | `3600` | Default request timeout in seconds |
 | `WEBHOOK_TIMEOUT_MS` | number | `5000` | Webhook delivery timeout in milliseconds |
 | `WEBHOOK_MAX_RETRIES` | number | `3` | Maximum webhook retry attempts |
+| `AGENTGATE_ALLOW_PRIVATE_WEBHOOKS` | boolean | `false` | **DEV/TEST ONLY.** When set (`1`/`true`), the webhook SSRF guard permits loopback / RFC-1918 private-range destinations (`127.0.0.1`, `::1`, `10.x`, `172.16-31.x`, `192.168.x`, `localhost`) so local integrations can register a `http://127.0.0.1:PORT` webhook. Cloud-metadata endpoints (`169.254.169.254`) and non-HTTP(S) protocols stay blocked. Default (unset) keeps the full SSRF-safe behavior. **Never enable in production** — startup emits a warning if it is on under `NODE_ENV=production`. |
 
 ### Slack Integration
 

--- a/packages/server/src/__tests__/config-edge-cases.test.ts
+++ b/packages/server/src/__tests__/config-edge-cases.test.ts
@@ -281,6 +281,30 @@ describe("config edge cases", () => {
       const warnings = validateProductionConfig(config);
       expect(warnings).toHaveLength(0);
     });
+
+    it("hard-refuses AGENTGATE_ALLOW_PRIVATE_WEBHOOKS in production (neutralized, not honored)", () => {
+      const config = parseConfig({
+        nodeEnv: "production",
+        allowPrivateWebhooks: true,
+        adminApiKey: "supersecretadminkey123",
+        jwtSecret: "very-long-jwt-secret-that-is-32-chars!!",
+        corsAllowedOrigins: "https://myapp.com",
+        webhookEncryptionKey: "my-encryption-key",
+        authMode: "api-key-only",
+      });
+      // The SSRF escape hatch can NEVER take effect in production, even when set.
+      expect(config.allowPrivateWebhooks).toBe(false);
+      expect(config.allowPrivateWebhooksRequested).toBe(true);
+      const warnings = validateProductionConfig(config);
+      expect(warnings.some((w) => w.includes("IGNORED"))).toBe(true);
+    });
+
+    it("honors AGENTGATE_ALLOW_PRIVATE_WEBHOOKS outside production", () => {
+      const dev = parseConfig({ nodeEnv: "development", allowPrivateWebhooks: true });
+      expect(dev.allowPrivateWebhooks).toBe(true);
+      const test = parseConfig({ nodeEnv: "test", allowPrivateWebhooks: true });
+      expect(test.allowPrivateWebhooks).toBe(true);
+    });
   });
 
   describe("singleton behavior edge cases", () => {

--- a/packages/server/src/__tests__/url-validator.test.ts
+++ b/packages/server/src/__tests__/url-validator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import dns from 'dns/promises';
 import { isPrivateIP, isCloudMetadata, validateWebhookUrl } from '../lib/url-validator.js';
 
@@ -289,6 +289,93 @@ describe('validateWebhookUrl', () => {
 
     it('rejects empty string', async () => {
       const result = await validateWebhookUrl('');
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('allowPrivate dev/test escape hatch', () => {
+    it('rejects loopback by default (flag unset)', async () => {
+      const result = await validateWebhookUrl('http://127.0.0.1:8787/webhook');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Private IP');
+    });
+
+    it('accepts loopback IP when allowPrivate is set', async () => {
+      const result = await validateWebhookUrl('http://127.0.0.1:8787/webhook', { allowPrivate: true });
+      expect(result.valid).toBe(true);
+      expect(result.resolvedIP).toBe('127.0.0.1');
+    });
+
+    it('accepts localhost hostname when allowPrivate is set', async () => {
+      // localhost is not a literal IP, so it goes through DNS resolution → 127.0.0.1
+      vi.mocked(dns.resolve4).mockResolvedValue(['127.0.0.1']);
+      vi.mocked(dns.resolve6).mockResolvedValue([]);
+
+      const result = await validateWebhookUrl('http://localhost:8787/webhook', { allowPrivate: true });
+      expect(result.valid).toBe(true);
+    });
+
+    it('STILL blocks localhost hostname by default (flag unset)', async () => {
+      const result = await validateWebhookUrl('http://localhost:8787/webhook');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('not allowed');
+    });
+
+    it('accepts private RFC-1918 IPs when allowPrivate is set', async () => {
+      expect((await validateWebhookUrl('http://10.0.0.5/hook', { allowPrivate: true })).valid).toBe(true);
+      expect((await validateWebhookUrl('http://192.168.1.10/hook', { allowPrivate: true })).valid).toBe(true);
+      expect((await validateWebhookUrl('http://172.20.0.1/hook', { allowPrivate: true })).valid).toBe(true);
+    });
+
+    it('accepts IPv6 loopback when allowPrivate is set', async () => {
+      const result = await validateWebhookUrl('http://[::1]:8787/webhook', { allowPrivate: true });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts hostname resolving to a private IP when allowPrivate is set', async () => {
+      vi.mocked(dns.resolve4).mockResolvedValue(['127.0.0.1']);
+      vi.mocked(dns.resolve6).mockResolvedValue([]);
+
+      const result = await validateWebhookUrl('http://lvh.me:8787/webhook', { allowPrivate: true });
+      expect(result.valid).toBe(true);
+    });
+
+    it('always accepts public URLs regardless of the flag', async () => {
+      vi.mocked(dns.resolve4).mockResolvedValue(['93.184.216.34']);
+      vi.mocked(dns.resolve6).mockResolvedValue([]);
+
+      expect((await validateWebhookUrl('https://example.com/webhook')).valid).toBe(true);
+      expect((await validateWebhookUrl('https://example.com/webhook', { allowPrivate: true })).valid).toBe(true);
+    });
+
+    it('STILL blocks cloud metadata even when allowPrivate is set', async () => {
+      const result = await validateWebhookUrl('http://169.254.169.254/latest/meta-data/', { allowPrivate: true });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('metadata');
+    });
+
+    it('STILL blocks cloud metadata hostnames even when allowPrivate is set', async () => {
+      const result = await validateWebhookUrl('http://metadata.google.internal/computeMetadata/v1/', { allowPrivate: true });
+      expect(result.valid).toBe(false);
+    });
+
+    it('STILL blocks a hostname resolving to the metadata IP when allowPrivate is set', async () => {
+      vi.mocked(dns.resolve4).mockResolvedValue(['169.254.169.254']);
+      vi.mocked(dns.resolve6).mockResolvedValue([]);
+
+      const result = await validateWebhookUrl('http://metadata-proxy.example.com/', { allowPrivate: true });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('metadata');
+    });
+
+    it('STILL blocks non-HTTP protocols even when allowPrivate is set', async () => {
+      const result = await validateWebhookUrl('file:///etc/passwd', { allowPrivate: true });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('HTTP');
+    });
+
+    it('STILL blocks decimal-encoded loopback by default', async () => {
+      const result = await validateWebhookUrl('http://2130706433/webhook');
       expect(result.valid).toBe(false);
     });
   });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -111,6 +111,16 @@ export const ConfigSchema = z.object({
   webhookTimeoutMs: z.coerce.number().int().min(100).default(5000),
   /** Max webhook retry attempts */
   webhookMaxRetries: z.coerce.number().int().min(0).default(3),
+  /** DEV/TEST ONLY — permit webhook destinations on loopback / RFC-1918 private
+   *  ranges (127.0.0.1, ::1, 10.x, 172.16-31.x, 192.168.x, localhost). Lets local
+   *  integrations (e.g. the AgentGate×UCP adapter demo) register a
+   *  http://127.0.0.1:PORT webhook without the SSRF guard rejecting it. Cloud
+   *  metadata endpoints and non-HTTP(S) protocols STAY blocked. Default off —
+   *  never enable in production. */
+  allowPrivateWebhooks: z
+    .union([z.boolean(), z.string()])
+    .transform((val) => (typeof val === "boolean" ? val : ["true", "1", "yes"].includes(val.toLowerCase())))
+    .default(false),
 
   // Slack Integration
   slackBotToken: z.string().optional(),
@@ -337,6 +347,7 @@ const ENV_MAP: Record<string, keyof z.infer<typeof ConfigSchema>> = {
   REQUEST_TIMEOUT_SEC: "requestTimeoutSec",
   WEBHOOK_TIMEOUT_MS: "webhookTimeoutMs",
   WEBHOOK_MAX_RETRIES: "webhookMaxRetries",
+  AGENTGATE_ALLOW_PRIVATE_WEBHOOKS: "allowPrivateWebhooks",
   SLACK_BOT_TOKEN: "slackBotToken",
   SLACK_SIGNING_SECRET: "slackSigningSecret",
   SLACK_DEFAULT_CHANNEL: "slackDefaultChannel",
@@ -509,6 +520,13 @@ export function validateProductionConfig(config: Config): string[] {
     }
     if (!config.webhookEncryptionKey) {
       warnings.push("WEBHOOK_ENCRYPTION_KEY should be set to encrypt webhook secrets at rest");
+    }
+    if (config.allowPrivateWebhooks) {
+      warnings.push(
+        "AGENTGATE_ALLOW_PRIVATE_WEBHOOKS is ON — the webhook SSRF guard is " +
+          "permitting loopback/private-range destinations. This is a dev/test-only " +
+          "escape hatch and must NOT be enabled in production.",
+      );
     }
     // Require OIDC config when auth mode needs it
     if (config.authMode !== "api-key-only") {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -317,6 +317,15 @@ export const ConfigSchema = z.object({
   isDevelopment: config.nodeEnv === "development",
   /** Convenience: true if nodeEnv === 'production' */
   isProduction: config.nodeEnv === "production",
+  /** What the operator requested via AGENTGATE_ALLOW_PRIVATE_WEBHOOKS (pre-refusal). */
+  allowPrivateWebhooksRequested: config.allowPrivateWebhooks,
+  // Hard-refuse the SSRF escape hatch in production: even if the env var is set, it
+  // can NEVER take effect when NODE_ENV=production. A dev-only ergonomics switch must
+  // not be able to open an SSRF hole in prod, so it is neutralized here — not merely
+  // warned about. All call sites read config.allowPrivateWebhooks, so this is the one
+  // enforcement point.
+  allowPrivateWebhooks:
+    config.nodeEnv === "production" ? false : config.allowPrivateWebhooks,
 }));
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -521,11 +530,14 @@ export function validateProductionConfig(config: Config): string[] {
     if (!config.webhookEncryptionKey) {
       warnings.push("WEBHOOK_ENCRYPTION_KEY should be set to encrypt webhook secrets at rest");
     }
-    if (config.allowPrivateWebhooks) {
+    // The escape hatch is hard-refused in production (see the config transform).
+    // If the operator set it anyway, tell them it was IGNORED so the silent-no-op
+    // isn't mistaken for it being active.
+    if (config.allowPrivateWebhooksRequested) {
       warnings.push(
-        "AGENTGATE_ALLOW_PRIVATE_WEBHOOKS is ON — the webhook SSRF guard is " +
-          "permitting loopback/private-range destinations. This is a dev/test-only " +
-          "escape hatch and must NOT be enabled in production.",
+        "AGENTGATE_ALLOW_PRIVATE_WEBHOOKS was set in production and has been IGNORED — " +
+          "the webhook SSRF guard stays fully enforced (loopback/private destinations " +
+          "blocked). This escape hatch is dev/test-only.",
       );
     }
     // Require OIDC config when auth mode needs it

--- a/packages/server/src/lib/notification/adapters/webhook.ts
+++ b/packages/server/src/lib/notification/adapters/webhook.ts
@@ -56,7 +56,9 @@ export class WebhookAdapter implements NotificationChannelAdapter {
     const timestamp = Date.now();
 
     // Validate URL and SSRF protection
-    const validation = await validateWebhookUrl(target);
+    const validation = await validateWebhookUrl(target, {
+      allowPrivate: config.allowPrivateWebhooks,
+    });
     if (!validation.valid) {
       return {
         success: false,

--- a/packages/server/src/lib/url-validator.ts
+++ b/packages/server/src/lib/url-validator.ts
@@ -48,10 +48,16 @@ const CLOUD_METADATA_HOSTNAMES = [
   'instance-data',
 ];
 
-// Blocked hostnames
-const BLOCKED_HOSTNAMES = [
+// Loopback / local hostnames — blocked by default, but permitted when the
+// dev/test allowPrivate escape hatch is on (see validateWebhookUrl).
+const LOOPBACK_HOSTNAMES = [
   'localhost',
   'localhost.localdomain',
+];
+
+// Blocked hostnames
+const BLOCKED_HOSTNAMES = [
+  ...LOOPBACK_HOSTNAMES,
   ...CLOUD_METADATA_HOSTNAMES,
 ];
 
@@ -105,18 +111,25 @@ export function isCloudMetadata(ip: string): boolean {
 }
 
 /**
- * Check if hostname is blocked
+ * Check if hostname is blocked.
+ *
+ * When `allowPrivate` is set (dev/test escape hatch), loopback hostnames such
+ * as `localhost` are permitted, but cloud-metadata hostnames stay blocked.
  */
-function isBlockedHostname(hostname: string): boolean {
+function isBlockedHostname(hostname: string, allowPrivate: boolean): boolean {
   const normalizedHost = hostname.toLowerCase();
-  
+
+  // In allowPrivate mode only cloud-metadata hostnames remain off-limits;
+  // otherwise the full blocklist (loopback + metadata) applies.
+  const blockList = allowPrivate ? CLOUD_METADATA_HOSTNAMES : BLOCKED_HOSTNAMES;
+
   // Direct match
-  if (BLOCKED_HOSTNAMES.includes(normalizedHost)) {
+  if (blockList.includes(normalizedHost)) {
     return true;
   }
 
   // Subdomain of blocked hostname
-  for (const blocked of BLOCKED_HOSTNAMES) {
+  for (const blocked of blockList) {
     if (normalizedHost.endsWith('.' + blocked)) {
       return true;
     }
@@ -180,13 +193,29 @@ export interface ValidationResult {
   resolvedIP?: string;
 }
 
+export interface ValidateWebhookOptions {
+  /**
+   * Dev/test ONLY: permit webhook destinations on loopback and RFC-1918/private
+   * ranges (127.0.0.1, ::1, 10.x, 172.16-31.x, 192.168.x, 169.254.x, localhost).
+   *
+   * Cloud metadata endpoints (169.254.169.254 & friends) and non-HTTP(S)
+   * protocols remain blocked even when this is set — so the guard still stops
+   * the canonical SSRF vectors. Default: false. Never enable in production.
+   */
+  allowPrivate?: boolean;
+}
+
 /**
  * Validate a webhook URL for SSRF vulnerabilities
  * Resolves DNS and checks if destination is safe
  */
-export async function validateWebhookUrl(url: string): Promise<ValidationResult> {
+export async function validateWebhookUrl(
+  url: string,
+  options: ValidateWebhookOptions = {},
+): Promise<ValidationResult> {
+  const allowPrivate = options.allowPrivate ?? false;
   let parsed: URL;
-  
+
   try {
     parsed = new URL(url);
   } catch {
@@ -201,7 +230,7 @@ export async function validateWebhookUrl(url: string): Promise<ValidationResult>
   const hostname = parsed.hostname;
 
   // Check blocked hostnames
-  if (isBlockedHostname(hostname)) {
+  if (isBlockedHostname(hostname, allowPrivate)) {
     return { valid: false, error: 'Hostname is not allowed' };
   }
 
@@ -212,7 +241,7 @@ export async function validateWebhookUrl(url: string): Promise<ValidationResult>
     if (isCloudMetadata(normalizedFromHost)) {
       return { valid: false, error: 'Cloud metadata endpoints are not allowed' };
     }
-    if (isPrivateIP(normalizedFromHost)) {
+    if (!allowPrivate && isPrivateIP(normalizedFromHost)) {
       return { valid: false, error: 'Private IP addresses are not allowed' };
     }
     return { valid: true, resolvedIP: normalizedFromHost };
@@ -224,7 +253,7 @@ export async function validateWebhookUrl(url: string): Promise<ValidationResult>
     if (isCloudMetadata(hostname)) {
       return { valid: false, error: 'Cloud metadata endpoints are not allowed' };
     }
-    if (isPrivateIP(hostname)) {
+    if (!allowPrivate && isPrivateIP(hostname)) {
       return { valid: false, error: 'Private IP addresses are not allowed' };
     }
     return { valid: true, resolvedIP: hostname };
@@ -237,7 +266,7 @@ export async function validateWebhookUrl(url: string): Promise<ValidationResult>
     if (isCloudMetadata(ipv6)) {
       return { valid: false, error: 'Cloud metadata endpoints are not allowed' };
     }
-    if (isPrivateIP(ipv6)) {
+    if (!allowPrivate && isPrivateIP(ipv6)) {
       return { valid: false, error: 'Private IP addresses are not allowed' };
     }
     return { valid: true, resolvedIP: ipv6 };
@@ -259,7 +288,7 @@ export async function validateWebhookUrl(url: string): Promise<ValidationResult>
       if (isCloudMetadata(ip)) {
         return { valid: false, error: `Hostname resolves to cloud metadata endpoint: ${ip}` };
       }
-      if (isPrivateIP(ip)) {
+      if (!allowPrivate && isPrivateIP(ip)) {
         return { valid: false, error: `Hostname resolves to private IP: ${ip}` };
       }
     }

--- a/packages/server/src/lib/webhook.ts
+++ b/packages/server/src/lib/webhook.ts
@@ -77,7 +77,9 @@ function getBackoffMs(attempt: number): number {
 
 async function attemptDelivery(deliveryId: string, url: string, payload: string, signature: string, attempt = 1) {
   // SSRF protection: Re-validate URL before each delivery attempt (DNS rebinding defense)
-  const validation = await validateWebhookUrl(url);
+  const validation = await validateWebhookUrl(url, {
+    allowPrivate: getConfig().allowPrivateWebhooks,
+  });
   if (!validation.valid) {
     await getDb().update(webhookDeliveries)
       .set({

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -28,7 +28,9 @@ router.post('/', zValidator('json', createWebhookSchema), async (c) => {
   const { url, events, secret } = c.req.valid('json');
   
   // SSRF protection: validate URL before accepting
-  const validation = await validateWebhookUrl(url);
+  const validation = await validateWebhookUrl(url, {
+    allowPrivate: getConfig().allowPrivateWebhooks,
+  });
   if (!validation.valid) {
     return c.json({ error: `Invalid webhook URL: ${validation.error}` }, 400);
   }
@@ -208,7 +210,9 @@ router.post('/deliveries/:id/replay', async (c) => {
   }
 
   // SSRF protection: re-validate URL
-  const validation = await validateWebhookUrl(webhook.url);
+  const validation = await validateWebhookUrl(webhook.url, {
+    allowPrivate: getConfig().allowPrivateWebhooks,
+  });
   if (!validation.valid) {
     return c.json({ error: `Webhook URL no longer valid: ${validation.error}` }, 400);
   }
@@ -375,7 +379,9 @@ router.patch('/:id', zValidator('json', updateWebhookSchema), async (c) => {
   
   // SSRF protection: validate URL if being updated
   if (updates.url) {
-    const validation = await validateWebhookUrl(updates.url);
+    const validation = await validateWebhookUrl(updates.url, {
+      allowPrivate: getConfig().allowPrivateWebhooks,
+    });
     if (!validation.valid) {
       return c.json({ error: `Invalid webhook URL: ${validation.error}` }, 400);
     }
@@ -409,7 +415,9 @@ router.post('/:id/test', async (c) => {
   }
   
   // SSRF protection: re-validate URL (DNS rebinding defense)
-  const validation = await validateWebhookUrl(webhookRecord.url);
+  const validation = await validateWebhookUrl(webhookRecord.url, {
+    allowPrivate: getConfig().allowPrivateWebhooks,
+  });
   if (!validation.valid) {
     return c.json({ error: `Webhook URL no longer valid: ${validation.error}` }, 400);
   }


### PR DESCRIPTION
Fixes #57.

Adds a **default-OFF** dev/test escape hatch to the webhook SSRF guard so local integrations can register loopback/private webhook destinations, without weakening the protections that actually matter.

- `validateWebhookUrl(url, { allowPrivate })` — new option (env `AGENTGATE_ALLOW_PRIVATE_WEBHOOKS=1`, config `allowPrivateWebhooks`). When set, loopback + RFC-1918/link-local ranges (127.0.0.1, ::1, 10.x, 172.16–31.x, 192.168.x, 169.254.x, `localhost`) are permitted.
- **Cloud-metadata endpoints and non-HTTP(S) stay blocked even with the flag on.** `isCloudMetadata()` is checked FIRST and unconditionally in every branch (hostname, direct-IP v4/v6, and DNS-resolved IP), so `169.254.169.254` (which is also link-local) is caught as metadata before the private-IP relaxation applies. Only the `isPrivateIP` block is gated behind `!allowPrivate`.
- Default (unset) behavior is byte-for-byte the old SSRF-safe path. All 6 call sites (create/update/replay/test routes, delivery re-validation, notification adapter) read `getConfig().allowPrivateWebhooks`. Added a production-startup warning; documented DEV/TEST-ONLY in `.env.example` + `CONFIG.md`.

**Tests:** `url-validator.test.ts` 57/57 — added an escape-hatch block covering rejected-by-default vs accepted-with-flag (loopback IP, `localhost`, 10/192.168/172.20, `[::1]`, DNS-to-private) and metadata IP + metadata hostname + DNS-to-metadata + `file://` still blocked with the flag on. Typecheck + lint clean.

Lets the AgentGate×UCP demo drop its `lvh.me` / dist-patching workaround via `export AGENTGATE_ALLOW_PRIVATE_WEBHOOKS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
